### PR TITLE
Update rename endpoint to refresh file extension

### DIFF
--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -378,9 +378,12 @@ public class FileController {
                             String.format("File '%s' already exists in current directory, %s", filename, location));
                 }
 
+                String extension = FileUtils.getFileExtension(filename);
+
                 FileOps ops = FileOps.builder()
                         .fileId(fileId)
                         .filename(filename)
+                        .extension(extension)
                         .build();
                 return fileService.updateFile(ops, true, Scope.FILENAME);
             });


### PR DESCRIPTION
## Summary
- update the rename endpoint to compute the new filename extension
- persist the computed extension when applying the rename operation

## Testing
- `mvn -pl . test` *(fails: network is unreachable while resolving the parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d372c54d7c8327930a51c121ddc6d8