### PR TITLE
feat: add rename support to file list

### DIFF
--- a/web/src/app/admin/_components/columns.tsx
+++ b/web/src/app/admin/_components/columns.tsx
@@ -3,7 +3,7 @@
 import { ColumnDef, Row } from "@tanstack/react-table";
 import dayjs from "dayjs";
 import { Edit, EditIcon, Import, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
@@ -150,6 +150,65 @@ const CreateRowActions = (
   );
 };
 
+const RemarkCell = ({
+  dataset,
+  onChangeRemark,
+}: {
+  dataset: Dataset;
+  onChangeRemark: (datasetId: string, remark: string) => void;
+}) => {
+  const [isHovering, setIsHovering] = useState(false);
+  const [isInputing, setIsInputing] = useState(false);
+  const [inputValue, setInputValue] = useState(dataset.remark);
+
+  useEffect(() => {
+    setInputValue(dataset.remark);
+  }, [dataset.remark]);
+
+  const handleBlur = () => {
+    setIsInputing(false);
+    onChangeRemark(dataset.dataset_id, inputValue);
+  };
+
+  return (
+    <div
+      className="min-w-6 flex items-center gap-1"
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
+      {isInputing ? (
+        <Input
+          autoFocus
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+          }}
+          onBlur={handleBlur}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : dataset.remark ? (
+        dataset.remark
+      ) : (
+        "-"
+      )}
+      <div className="size-9">
+        {(isHovering || isInputing) && (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsInputing(true);
+            }}
+          >
+            <EditIcon size={16} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export const getColumns = (
   onChangeRemark: (datasetId: string, remark: string) => void,
   onDelete: () => void,
@@ -162,47 +221,9 @@ export const getColumns = (
   {
     accessorKey: "remark",
     header: "描述",
-    cell({ row }) {
-      const [isHovering, setIsHovering] = useState(false);
-      const [isInputing, setIsInputing] = useState(false);
-      const [inputValue, setInputValue] = useState(row.original.remark);
-      return (
-        <div
-          className="min-w-6 flex items-center gap-1"
-          onMouseEnter={() => setIsHovering(true)}
-          onMouseLeave={() => setIsHovering(false)}
-        >
-          {isInputing ? (
-            <Input
-              autoFocus
-              value={inputValue}
-              onChange={(e) => {
-                setInputValue(e.target.value);
-              }}
-              onBlur={() => {
-                setIsInputing(false);
-                onChangeRemark(row.original.dataset_id, inputValue);
-              }}
-            />
-          ) : row.original.remark ? (
-            row.original.remark
-          ) : (
-            "-"
-          )}
-          <div className="size-9">
-            {isHovering && (
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={() => setIsInputing(true)}
-              >
-                <EditIcon size={16} />
-              </Button>
-            )}
-          </div>
-        </div>
-      );
-    },
+    cell: ({ row }) => (
+      <RemarkCell dataset={row.original} onChangeRemark={onChangeRemark} />
+    ),
   },
   {
     accessorFn(row) {

--- a/web/src/app/admin/_components/tab-content.tsx
+++ b/web/src/app/admin/_components/tab-content.tsx
@@ -6,7 +6,6 @@ import { getColumns } from "./columns";
 import { useUserStore } from "@/store/user";
 import { useAdminStore } from "../model";
 import CreateDatasetSheet from "../_components/create-dataset-sheet";
-import { requestUpdateDatasetRemark } from "@/request/dataset";
 interface TabContentProps {
   type: "qa" | "document";
 }
@@ -32,7 +31,7 @@ const TabContent = ({ type }: TabContentProps) => {
       },
       type,
     );
-  }, [getDatasetList, type]);
+  }, [getDatasetList, type, updateDatasetRemark]);
   const [open, setOpen] = useState(false);
 
   return (

--- a/web/src/app/admin/files/_components/columns.tsx
+++ b/web/src/app/admin/files/_components/columns.tsx
@@ -10,6 +10,7 @@ import {
   FileIcon,
   FileJsonIcon,
   FolderIcon,
+  Pencil,
 } from "lucide-react";
 import {
   RiFileExcel2Line,
@@ -20,60 +21,172 @@ import {
   RiMarkdownLine,
 } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useEffect, useRef, useState } from "react";
 
-export const getColumns = (): ColumnDef<KnowledgeFile>[] => [
+type GetColumnsOptions = {
+  onRename: (file: KnowledgeFile, filename: string) => Promise<boolean>;
+};
+
+const FilenameCell = ({
+  file,
+  displayName,
+  onRename,
+}: {
+  file: KnowledgeFile;
+  displayName: string;
+  onRename: (file: KnowledgeFile, filename: string) => Promise<boolean>;
+}) => {
+  const isDir = file.is_dir;
+  const isImage = file.mime_type.startsWith("image/");
+  const extension = file.mime_type.split("/")[1];
+  const props = {
+    size: 24,
+  };
+  let icon = <FileIcon {...props} />;
+  if (isDir) {
+    icon = <FolderIcon {...props} />;
+  }
+  if (extension === "pdf") {
+    icon = <RiFilePdf2Line {...props} />;
+  }
+
+  if (extension === "json") {
+    icon = <FileJsonIcon {...props} />;
+  }
+
+  if (extension === "doc" || extension === "docx") {
+    icon = <RiFileWord2Line {...props} />;
+  }
+
+  if (extension === "xls" || extension === "xlsx" || extension === "csv") {
+    icon = <RiFileExcel2Line {...props} />;
+  }
+
+  if (isImage) {
+    icon = <RiImage2Line {...props} />;
+  }
+
+  if (extension === "md") {
+    icon = <RiMarkdownLine {...props} />;
+  }
+
+  if (extension === "ppt" || extension === "pptx") {
+    icon = <RiFilePpt2Line {...props} />;
+  }
+
+  const [isHovering, setIsHovering] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(file.filename);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setInputValue(file.filename);
+  }, [file.filename]);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const handleRename = async () => {
+    if (isRenaming) {
+      return;
+    }
+    const trimmedValue = inputValue.trim();
+    if (!trimmedValue) {
+      setInputValue(file.filename);
+      setIsEditing(false);
+      return;
+    }
+    if (trimmedValue === file.filename) {
+      setIsEditing(false);
+      return;
+    }
+    setIsRenaming(true);
+    const success = await onRename(file, trimmedValue);
+    setIsRenaming(false);
+    if (success) {
+      setIsEditing(false);
+    } else {
+      setInputValue(file.filename);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => {
+        if (!isEditing) {
+          setIsHovering(false);
+        }
+      }}
+    >
+      {icon}
+      {isEditing ? (
+        <Input
+          ref={inputRef}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onBlur={handleRename}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleRename();
+            }
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setInputValue(file.filename);
+              setIsEditing(false);
+            }
+          }}
+          className="h-8 w-[240px]"
+        />
+      ) : (
+        <span className="flex max-w-[240px] items-center truncate" title={displayName}>
+          {displayName}
+        </span>
+      )}
+      <div className="flex h-9 w-9 items-center justify-center">
+        {(isHovering || isEditing) && (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsEditing(true);
+              setIsHovering(true);
+            }}
+            disabled={isRenaming}
+          >
+            <Pencil size={16} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const getColumns = ({ onRename }: GetColumnsOptions): ColumnDef<KnowledgeFile>[] => [
   {
     accessorKey: "filename",
     header: "名称",
-    cell: ({ row }) => {
-      const data = row.original;
-      const isDir = data.is_dir;
-      const isImage = data.mime_type.startsWith("image/");
-      const extension = data.mime_type.split("/")[1];
-      const props = {
-        size: 24,
-      };
-      let icon = <FileIcon {...props} />;
-      if (isDir) {
-        icon = <FolderIcon {...props} />;
-      }
-      if (extension === "pdf") {
-        icon = <RiFilePdf2Line {...props} />;
-      }
-
-      if (extension === "json") {
-        icon = <FileJsonIcon {...props} />;
-      }
-
-      if (extension === "doc" || extension === "docx") {
-        icon = <RiFileWord2Line {...props} />;
-      }
-
-      if (extension === "xls" || extension === "xlsx" || extension === "csv") {
-        icon = <RiFileExcel2Line {...props} />;
-      }
-
-      if (isImage) {
-        icon = <RiImage2Line {...props} />;
-      }
-
-      if (extension === "md") {
-        icon = <RiMarkdownLine {...props} />;
-      }
-
-      if (extension === "ppt" || extension === "pptx") {
-        icon = <RiFilePpt2Line {...props} />;
-      }
-
-      return (
-        <div className="flex items-center gap-2">
-          {icon}
-          <span title={row.getValue("filename")}>
-            {row.getValue("filename")}
-          </span>
-        </div>
-      );
-    },
+    cell: ({ row }) => (
+      <FilenameCell
+        file={row.original}
+        displayName={row.getValue("filename") as string}
+        onRename={onRename}
+      />
+    ),
   },
   {
     accessorKey: "extension",

--- a/web/src/app/admin/files/_components/data-table.tsx
+++ b/web/src/app/admin/files/_components/data-table.tsx
@@ -92,7 +92,7 @@ export function DataTable<TValue>({
 
   useEffect(() => {
     table.resetColumnFilters();
-  }, [data]);
+  }, [data, table]);
 
   const onClickSelectItem = (
     e: React.MouseEvent<HTMLDivElement>,

--- a/web/src/app/admin/files/model.ts
+++ b/web/src/app/admin/files/model.ts
@@ -1,8 +1,12 @@
 import { KnowledgeFile } from "@/lib/types/file";
-import { findFiles, postCreateFolder, postUploadFile } from "@/request/files";
+import {
+  findFiles,
+  postCreateFolder,
+  postRenameFile,
+  postUploadFile,
+} from "@/request/files";
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
-import { useUserStore } from "@/store/user";
 
 // 需要设计文件夹的栈
 // 并且需要存每个文件夹下有哪些文件
@@ -23,6 +27,11 @@ type Action = {
   jumpFolder: (id: string, spaceCode?: string) => Promise<void>;
   backFolder: () => void;
   uploadFile: (file: File, ancestor_id: string) => Promise<boolean>;
+  renameFile: (
+    file: KnowledgeFile,
+    filename: string,
+    ancestorId: string,
+  ) => Promise<boolean>;
 };
 export const store = create<State & Action>()((set, get) => ({
   currentDirStack: [
@@ -132,6 +141,29 @@ export const store = create<State & Action>()((set, get) => ({
         [ancestor_id]: [res, ...get().files[ancestor_id]],
       };
       set({ files: newFiles });
+      return true;
+    }
+    return false;
+  },
+  renameFile: async (file: KnowledgeFile, filename: string, ancestorId: string) => {
+    const res = await postRenameFile(file.id, filename);
+    if (res) {
+      set((state) => {
+        const siblingFiles = state.files[ancestorId] || [];
+        const newFiles = {
+          ...state.files,
+          [ancestorId]: siblingFiles.map((item) =>
+            item.id === file.id ? { ...item, filename: res.filename } : item,
+          ),
+        };
+        const newCurrentDirStack = state.currentDirStack.map((dir) =>
+          dir.id === file.id ? { ...dir, name: res.filename } : dir,
+        );
+        return {
+          files: newFiles,
+          currentDirStack: newCurrentDirStack,
+        };
+      });
       return true;
     }
     return false;

--- a/web/src/app/admin/files/page.tsx
+++ b/web/src/app/admin/files/page.tsx
@@ -6,7 +6,7 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useModel } from "./model";
 import { ArrowLeftIcon } from "lucide-react";
 import { KnowledgeFile } from "@/lib/types/file";
@@ -58,6 +58,7 @@ const Page = () => {
     createFolder,
     backFolder,
     uploadFile,
+    renameFile,
   } = useModel();
   const currentDir = currentDirStack[currentDirStack.length - 1];
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
@@ -106,9 +107,22 @@ const Page = () => {
     };
     input.click();
   };
+  const handleRename = useCallback(
+    async (file: KnowledgeFile, filename: string) => {
+      const success = await renameFile(file, filename, currentDir.id);
+      if (success) {
+        toast.success("重命名成功");
+      }
+      return success;
+    },
+    [renameFile, currentDir.id],
+  );
+
   const columns = useMemo(() => {
-    return getColumns();
-  }, []);
+    return getColumns({
+      onRename: handleRename,
+    });
+  }, [handleRename]);
   const handleCreateFolder = async (
     values: z.infer<typeof createFolderFormSchema>,
   ) => {
@@ -123,7 +137,7 @@ const Page = () => {
     if (currentWorkspace) {
       initPage(currentWorkspace.spaceCode);
     }
-  }, [currentWorkspace]);
+  }, [currentWorkspace, initPage]);
   return (
     <>
       <div className="flex items-center justify-between">

--- a/web/src/app/api/files/[fileId]/rename/route.ts
+++ b/web/src/app/api/files/[fileId]/rename/route.ts
@@ -1,0 +1,34 @@
+import { backendRequest } from "@/lib/request/backend";
+import { FILE_API_URL } from "@/lib/request/const";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { fileId: string } },
+) {
+  const filename = req.nextUrl.searchParams.get("filename");
+  if (!filename) {
+    return NextResponse.json({
+      code: 400,
+      message: "filename is required",
+    });
+  }
+
+  const res = await backendRequest(req, {
+    url: `${FILE_API_URL}/v1/files/${params.fileId}/rename`,
+    method: "POST",
+    query: {
+      filename,
+    },
+  });
+
+  const data = await res.json();
+  if (data.code === 401) {
+    return NextResponse.json(data);
+  }
+
+  return NextResponse.json({
+    code: 200,
+    data,
+  });
+}

--- a/web/src/app/api/files/upload/route.ts
+++ b/web/src/app/api/files/upload/route.ts
@@ -1,4 +1,4 @@
-import { backendRequest, backendRequestFormData } from "@/lib/request/backend";
+import { backendRequestFormData } from "@/lib/request/backend";
 import { FILE_API_URL } from "@/lib/request/const";
 import { NextRequest } from "next/server";
 

--- a/web/src/app/document-parser/_components/document-content.tsx
+++ b/web/src/app/document-parser/_components/document-content.tsx
@@ -13,7 +13,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDocumentParserStore } from "../model";
-import { webRequest } from "@/lib/request/web";
 import { toast } from "sonner";
 import { getFilePreviewUrl } from "@/request/files";
 

--- a/web/src/app/document-preview/_components/right-document-section.tsx
+++ b/web/src/app/document-preview/_components/right-document-section.tsx
@@ -5,7 +5,6 @@ import { DocumentSection } from "./document-section";
 import { DocumentViewerRef } from "@/components/document-viewer";
 import UploadDialog from "@/components/upload-dialog";
 import { useDocumentPreviewStore } from "../model";
-import { toast } from "sonner";
 import { ReferenceSectionRef } from "./reference-section";
 
 interface RightDocumentSectionProps {

--- a/web/src/request/files.ts
+++ b/web/src/request/files.ts
@@ -1,6 +1,6 @@
 import { webRequest, webRequestFormData } from "@/lib/request/web";
 import { KnowledgeFile } from "@/lib/types/file";
-import { anOldHope } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { toast } from "sonner";
 
 export async function getFileList() {
   const res = await webRequest<{ data: KnowledgeFile[] }>({
@@ -74,6 +74,21 @@ export async function postUploadFile(data: {
   if (res.code === 200) {
     return res.data;
   }
+  return null;
+}
+
+export async function postRenameFile(fileId: string, filename: string) {
+  const res = await webRequest<KnowledgeFile>({
+    path: `/api/files/${fileId}/rename`,
+    method: "POST",
+    query: {
+      filename,
+    },
+  });
+  if (res.code === 200) {
+    return res.data;
+  }
+  toast.error(res.message || "重命名失败");
   return null;
 }
 


### PR DESCRIPTION
## Summary
- add a hover edit button and inline rename flow to the admin file table
- wire the new rename action through the file model and API client
- refactor dataset remark cell and clean up lint issues encountered during the change

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d38dba1830832798a1c4f15d157436