### PR TITLE
feat: allow optional type parameter and apply purpose filter only to files when querying mixed results

### DIFF
--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1243,8 +1243,10 @@ public class FileController {
         // 校验spaceCode和ancestorId至少提供一个
         Assert.isTrue(StringUtils.isNotEmpty(ops.getSpaceCode()) || StringUtils.isNotEmpty(ops.getAncestorId()),
                 "either space_code or ancestor_id must be provided");
-        Assert.hasText(ops.getType(), "type is required");
-        Assert.isTrue("dir".equals(ops.getType()) || "file".equals(ops.getType()), "type must be 'dir' or 'file', but got: " + ops.getType());
+        // type 为可选参数，如果提供则必须是 dir 或 file
+        if(ops.getType() != null) {
+            Assert.isTrue("dir".equals(ops.getType()) || "file".equals(ops.getType()), "type must be 'dir' or 'file', but got: " + ops.getType());
+        }
         Assert.isTrue(ops.getPage() >= 1, "page must be greater than 0");
         Assert.isTrue(ops.getPageSize() >= 1, "page_size must be greater than 0");
         Assert.isTrue(ops.getPageSize() <= 100, "page_size cannot exceed 100");

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -634,6 +634,11 @@ public class FileRepo implements BaseRepo {
         if(StringUtils.isEmpty(ops.getAncestorId())) {
             fileCondition = fileCondition.and(FILE.SPACE_CODE.eq(ops.getSpaceCode()));
         }
+        if("dir".equals(ops.getType())) {
+            fileCondition = fileCondition.and(FILE.IS_DIR.eq(1));
+        } else if("file".equals(ops.getType())) {
+            fileCondition = fileCondition.and(FILE.IS_DIR.eq(0));
+        }
         if(ops.getPurpose() != null) {
             fileCondition = fileCondition.and(FILE.PURPOSE.eq(ops.getPurpose()));
         }
@@ -646,16 +651,6 @@ public class FileRepo implements BaseRepo {
         }
         if(ops.getExtension() != null) {
             fileCondition = fileCondition.and(FILE.EXTENSION.eq(ops.getExtension()));
-        }
-        switch (ops.getType()) {
-        case "dir":
-            fileCondition = fileCondition.and(FILE.IS_DIR.eq(1));
-            break;
-        case "file":
-            fileCondition = fileCondition.and(FILE.IS_DIR.eq(0));
-            break;
-        default:
-            break;
         }
         if(ops.getTags() != null) {
             fileCondition = applyJsonArrayFilter(fileCondition, FILE.TAGS, ops.getTags());

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
@@ -239,4 +239,248 @@ public class FileControllerPageFilesTest {
                 ops.getPageSize() == 10 &&
                 "desc".equalsIgnoreCase(ops.getOrder())));
     }
+
+    // ========== 新增测试：type 参数可选和校验 ==========
+
+    @Test
+    public void pageFiles_MissingType_Success() throws Exception {
+        // Given: 不传 type 参数，应该成功并返回所有 file 和 dir
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true).build(),
+                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false).build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value("dir-1"))
+                .andExpect(jsonPath("$.data[1].id").value("file-1"));
+
+        // 验证 type 参数为 null
+        verify(fileService).pageFiles(argThat(ops -> ops.getType() == null));
+    }
+
+    @Test
+    public void pageFiles_EmptyStringType_BadRequest() throws Exception {
+        // Given: type 为空字符串，应该报错
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"type\": \"\",\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("type must be 'dir' or 'file', but got: "));
+    }
+
+    @Test
+    public void pageFiles_InvalidType_BadRequest() throws Exception {
+        // Given: type 为无效值，应该报错
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"type\": \"folder\",\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("type must be 'dir' or 'file', but got: folder"));
+    }
+
+    @Test
+    public void pageFiles_TypeDir_Success() throws Exception {
+        // Given: type 为 dir，应该只返回目录
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true).build(),
+                OpenAIFile.builder().id("dir-2").filename("folder2").isDir(true).build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"type\": \"dir\",\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk());
+
+        // 验证 type 参数为 "dir"
+        verify(fileService).pageFiles(argThat(ops -> "dir".equals(ops.getType())));
+    }
+
+    @Test
+    public void pageFiles_TypeFileWithoutPurpose_Success() throws Exception {
+        // Given: type 为 file 但不传 purpose，应该返回所有文件
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false).purpose("assistants").build(),
+                OpenAIFile.builder().id("file-2").filename("img.jpg").isDir(false).purpose("vision").build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"type\": \"file\",\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value("file-1"))
+                .andExpect(jsonPath("$.data[1].id").value("file-2"));
+
+        // 验证 type 为 file 且 purpose 为 null
+        verify(fileService).pageFiles(argThat(ops -> "file".equals(ops.getType()) && ops.getPurpose() == null));
+    }
+
+    @Test
+    public void pageFiles_NoTypeNoPurpose_Success() throws Exception {
+        // Given: 既不传 type 也不传 purpose，应该返回所有文件和目录
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("dir-1").filename("folder").isDir(true).build(),
+                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false).purpose("assistants").build(),
+                OpenAIFile.builder().id("file-2").filename("img.jpg").isDir(false).purpose("vision").build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(3).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value("dir-1"))
+                .andExpect(jsonPath("$.data[1].id").value("file-1"))
+                .andExpect(jsonPath("$.data[2].id").value("file-2"));
+
+        // 验证 type 和 purpose 都为 null
+        verify(fileService).pageFiles(argThat(ops -> ops.getType() == null && ops.getPurpose() == null));
+    }
+
+    // ========== 新增测试：purpose 和 type 的组合场景 ==========
+
+    @Test
+    public void pageFiles_PurposeWithoutType_Success() throws Exception {
+        // Given: 传 purpose 但不传 type，应该返回所有 dir + purpose 匹配的 file
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true).purpose(null).build(),
+                OpenAIFile.builder().id("file-1").filename("vision.jpg").isDir(false).purpose("vision").build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"purpose\": \"vision\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value("dir-1"))
+                .andExpect(jsonPath("$.data[1].id").value("file-1"))
+                .andExpect(jsonPath("$.data[1].purpose").value("vision"));
+
+        // 验证 purpose 有值但 type 为 null
+        verify(fileService).pageFiles(argThat(ops -> "vision".equals(ops.getPurpose()) && ops.getType() == null));
+    }
+
+    @Test
+    public void pageFiles_PurposeWithTypeFile_Success() throws Exception {
+        // Given: 传 purpose 且 type 为 file，应该只返回 purpose 匹配的 file
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("file-1").filename("vision.jpg").isDir(false).purpose("vision").build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(1).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"purpose\": \"vision\",\n" +
+                        "  \"type\": \"file\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].purpose").value("vision"));
+
+        // 验证 purpose 和 type 都有值
+        verify(fileService).pageFiles(argThat(ops -> "vision".equals(ops.getPurpose()) && "file".equals(ops.getType())));
+    }
+
+    @Test
+    public void pageFiles_PurposeWithTypeDir_Success() throws Exception {
+        // Given: 传 purpose 且 type 为 dir，应该只返回 dir（purpose 对 dir 无实际过滤效果）
+        int page = 1;
+        int pageSize = 10;
+        List<OpenAIFile> data = Arrays.asList(
+                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true).purpose(null).build());
+
+        when(fileService.pageFiles(any(PageFileOps.class)))
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(1).list(data));
+
+        // When & Then
+        mockMvc.perform(post("/v1/files/page")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "  \"space_code\": \"space-1\",\n" +
+                        "  \"purpose\": \"vision\",\n" +
+                        "  \"type\": \"dir\",\n" +
+                        "  \"page\": 1,\n" +
+                        "  \"page_size\": 10,\n" +
+                        "  \"order\": \"desc\"\n" +
+                        "}"))
+                .andExpect(status().isOk());
+
+        // 验证 purpose 和 type 都有值
+        verify(fileService).pageFiles(argThat(ops -> "vision".equals(ops.getPurpose()) && "dir".equals(ops.getType())));
+    }
 }


### PR DESCRIPTION
# Pull Request

## Description

- allow optional type parameter and apply purpose filter only to files when querying mixed results

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change

## Component

Please check the components affected by this PR:

- [x] 🔧 API (Backend)
- [ ] 🎨 Web (Frontend)
- [ ] 🐳 Docker/Infrastructure
- [ ] 📖 Documentation
- [ ] 🧪 Tests
- [ ] 📦 Dependencies

## Testing

Please describe the tests that you ran to verify your changes:

- [ ] Unit tests pass (`npm test` / `mvn test`)
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Docker build successful

**Test Configuration**:
- OS: [e.g. Ubuntu 20.04]
- Node.js version: [e.g. 20.x]
- Java version: [e.g. 8]

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Notes

Add any additional notes, concerns, or questions here.