### PR TITLE
Build #60: Support moving directory subtrees

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -171,6 +171,11 @@
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1224,18 +1224,18 @@ public class FileController {
             throw new FileNotFoundException(fileId);
         }
         Assert.isTrue(StringUtils.equals(ancestor.getSpaceCode(), file.getSpaceCode()), "space mismatch for file_id and ancestor_id");
-        Assert.isTrue(file.getIsDir() == 0, "file_id must be refer to a file");
-
-        // validate no duplicate names and not same directory
-        String currentAncestorId = fileService.getDirectAncestorId(fileId);
-        Assert.isTrue(!StringUtils.equals(currentAncestorId, targetAncestorId), "file already in target directory");
-
-        boolean exists = fileService.exists(ancestor.getSpaceCode(), targetAncestorId, file.getFilename());
-        Assert.isTrue(!exists, "filename already exists");
 
         try {
             return fl.executeWithLock(ancestor.getSpaceCode(), targetAncestorId, file.getFilename(), FILE_LOCK_TIMEOUT_MS,
-                    () -> fileService.moveFile(fileId, targetAncestorId));
+                    () -> {
+                        String currentAncestorId = fileService.getDirectAncestorId(fileId);
+                        Assert.isTrue(!StringUtils.equals(currentAncestorId, targetAncestorId), "file already in target directory");
+
+                        boolean exists = fileService.exists(ancestor.getSpaceCode(), targetAncestorId, file.getFilename());
+                        Assert.isTrue(!exists, "filename already exists");
+
+                        return fileService.moveFile(fileId, targetAncestorId);
+                    });
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1226,16 +1226,19 @@ public class FileController {
         Assert.isTrue(StringUtils.equals(ancestor.getSpaceCode(), file.getSpaceCode()), "space mismatch for file_id and ancestor_id");
 
         try {
-            return fl.executeWithLock(ancestor.getSpaceCode(), targetAncestorId, file.getFilename(), FILE_LOCK_TIMEOUT_MS,
-                    () -> {
-                        String currentAncestorId = fileService.getDirectAncestorId(fileId);
-                        Assert.isTrue(!StringUtils.equals(currentAncestorId, targetAncestorId), "file already in target directory");
+            boolean directory = file.getIsDir() == 1;
+            return fl.executeWithMoveLock(ancestor.getSpaceCode(), directory, FILE_LOCK_TIMEOUT_MS,
+                    () -> fl.executeWithLock(ancestor.getSpaceCode(), targetAncestorId, file.getFilename(), FILE_LOCK_TIMEOUT_MS,
+                            () -> {
+                                String currentAncestorId = fileService.getDirectAncestorId(fileId);
+                                Assert.isTrue(!StringUtils.equals(currentAncestorId, targetAncestorId),
+                                        "file already in target directory");
 
-                        boolean exists = fileService.exists(ancestor.getSpaceCode(), targetAncestorId, file.getFilename());
-                        Assert.isTrue(!exists, "filename already exists");
+                                boolean exists = fileService.exists(ancestor.getSpaceCode(), targetAncestorId, file.getFilename());
+                                Assert.isTrue(!exists, "filename already exists");
 
-                        return fileService.moveFile(fileId, targetAncestorId);
-                    });
+                                return fileService.moveFile(fileId, targetAncestorId);
+                            }));
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -8,7 +8,6 @@ import static com.ke.bella.files.db.Tables.FILE_SHARDING;
 import static com.ke.bella.files.db.repo.DSLContextHolder.targetTableName;
 import static org.jooq.impl.DSL.field;
 
-import java.sql.Statement;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -25,15 +24,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
+import org.jooq.Field;
 import org.jooq.InsertSetMoreStep;
-import org.jooq.Query;
 import org.jooq.Record;
 import org.jooq.Record1;
 import org.jooq.Record3;
 import org.jooq.Result;
+import org.jooq.SQLDialect;
 import org.jooq.SelectConditionStep;
 import org.jooq.SelectOrderByStep;
 import org.jooq.SortField;
+import org.jooq.Table;
 import org.jooq.UpdateSetMoreStep;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Component;
@@ -553,8 +554,8 @@ public class FileRepo implements BaseRepo {
                 .filter(ancestorId -> !StringUtils.equals(ancestorId, fileId))
                 .collect(Collectors.toList());
 
-        return new ClosureMoveSnapshot(subtreeClosures, targetAncestorClosures, subtreeIds,
-                externalAncestorIds, targetSelfClosure.getRootDepth());
+        return new ClosureMoveSnapshot(subtreeIds, externalAncestorIds, targetAncestorId,
+                targetAncestorClosures.size(), targetSelfClosure.getRootDepth());
     }
 
     private void deleteExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
@@ -572,57 +573,86 @@ public class FileRepo implements BaseRepo {
     }
 
     private void insertExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
-        List<InsertSetMoreStep<FileClosureRecord>> inserts = new ArrayList<>();
-        for (FileClosureRecord targetAncestorClosure : snapshot.targetAncestorClosures) {
-            for (FileClosureRecord subtreeClosure : snapshot.subtreeClosures) {
-                long depth = targetAncestorClosure.getDepth() + 1 + subtreeClosure.getDepth();
-                inserts.add(createFileClosureInsert(dsl, subtreeClosure.getDescendantId(),
-                        targetAncestorClosure.getAncestorId(), depth));
-            }
+        Table<FileClosureRecord> target = FILE_CLOSURE.as("target_closure");
+        Table<FileClosureRecord> subtree = FILE_CLOSURE.as("subtree_closure");
+        Field<String> targetAncestorId = target.field(FILE_CLOSURE.ANCESTOR_ID);
+        Field<Long> targetDepth = target.field(FILE_CLOSURE.DEPTH);
+        Field<String> targetDescendantId = target.field(FILE_CLOSURE.DESCENDANT_ID);
+        Field<String> subtreeAncestorId = subtree.field(FILE_CLOSURE.ANCESTOR_ID);
+        Field<String> subtreeDescendantId = subtree.field(FILE_CLOSURE.DESCENDANT_ID);
+        Field<Long> subtreeDepth = subtree.field(FILE_CLOSURE.DEPTH);
+        FileClosureRecord audit = FILE_CLOSURE.newRecord();
+        fillCreatorInfo(audit);
+
+        int insertedCount = dsl.insertInto(FILE_CLOSURE,
+                FILE_CLOSURE.ANCESTOR_ID, FILE_CLOSURE.DESCENDANT_ID, FILE_CLOSURE.SPACE_CODE,
+                FILE_CLOSURE.DEPTH, FILE_CLOSURE.ROOT_DEPTH, FILE_CLOSURE.CUID, FILE_CLOSURE.CU_NAME,
+                FILE_CLOSURE.CTIME, FILE_CLOSURE.MUID, FILE_CLOSURE.MU_NAME, FILE_CLOSURE.MTIME)
+                .select(dsl.select(targetAncestorId, subtreeDescendantId,
+                        DSL.val(BellaContextHelper.getOperateSpaceCode()), targetDepth.add(1L).add(subtreeDepth),
+                        DSL.val(-1L), DSL.val(audit.getCuid() == null ? 0L : audit.getCuid()),
+                        DSL.val(audit.getCuName() == null ? "" : audit.getCuName()), DSL.val(audit.getCtime()),
+                        DSL.val(audit.getMuid() == null ? 0L : audit.getMuid()),
+                        DSL.val(audit.getMuName() == null ? "" : audit.getMuName()), DSL.val(audit.getMtime()))
+                        .from(target)
+                        .crossJoin(subtree)
+                        .where(targetDescendantId.eq(snapshot.targetAncestorId))
+                        .and(subtreeAncestorId.eq(fileId)))
+                .execute();
+
+        int expectedInsertCount = snapshot.targetAncestorCount * snapshot.subtreeIds.size();
+        if(insertedCount != expectedInsertCount) {
+            throw new IllegalStateException("insert moved file_closure failed, fileId: " + fileId);
         }
-        assertBatchSucceeded(dsl.batch(inserts).execute(), inserts.size(),
-                "batch insert moved file_closure failed, fileId: " + fileId);
     }
 
     private void updateSubtreeRootDepths(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
-        List<Query> rootDepthUpdates = new ArrayList<>();
-        for (FileClosureRecord subtreeClosure : snapshot.subtreeClosures) {
-            long rootDepth = snapshot.targetRootDepth + 1 + subtreeClosure.getDepth();
-            rootDepthUpdates.add(dsl.update(FILE_CLOSURE)
-                    .set(FILE_CLOSURE.ROOT_DEPTH, rootDepth)
-                    .where(FILE_CLOSURE.ANCESTOR_ID.eq(subtreeClosure.getDescendantId()))
-                    .and(FILE_CLOSURE.DESCENDANT_ID.eq(subtreeClosure.getDescendantId()))
-                    .and(FILE_CLOSURE.DEPTH.eq(0L)));
+        long rootDepthOffset = snapshot.targetRootDepth + 1L;
+        int updatedCount;
+        if(isH2Database(dsl)) {
+            updatedCount = dsl.execute("update {0} self_closure "
+                            + "set root_depth = {1} + (select subtree_closure.depth from {0} subtree_closure "
+                            + "where subtree_closure.ancestor_id = {2} "
+                            + "and subtree_closure.descendant_id = self_closure.descendant_id) "
+                            + "where self_closure.ancestor_id = self_closure.descendant_id "
+                            + "and self_closure.depth = 0 "
+                            + "and exists (select 1 from {0} subtree_closure "
+                            + "where subtree_closure.ancestor_id = {2} "
+                            + "and subtree_closure.descendant_id = self_closure.descendant_id)",
+                    FILE_CLOSURE, DSL.val(rootDepthOffset), DSL.val(fileId));
+        } else {
+            updatedCount = dsl.execute("update {0} self_closure "
+                            + "join {0} subtree_closure "
+                            + "on subtree_closure.ancestor_id = {1} "
+                            + "and subtree_closure.descendant_id = self_closure.descendant_id "
+                            + "set self_closure.root_depth = {2} + subtree_closure.depth "
+                            + "where self_closure.ancestor_id = self_closure.descendant_id "
+                            + "and self_closure.depth = 0",
+                    FILE_CLOSURE, DSL.val(fileId), DSL.val(rootDepthOffset));
         }
-        assertBatchSucceeded(dsl.batch(rootDepthUpdates).execute(), rootDepthUpdates.size(),
-                "batch update file_closure root_depth failed, fileId: " + fileId);
+        if(updatedCount != snapshot.subtreeIds.size()) {
+            throw new IllegalStateException("update file_closure root_depth failed, fileId: " + fileId);
+        }
+    }
+
+    private boolean isH2Database(DSLContext dsl) {
+        return dsl.dialect().family() == SQLDialect.H2;
     }
 
     private static class ClosureMoveSnapshot {
-        private final List<FileClosureRecord> subtreeClosures;
-        private final List<FileClosureRecord> targetAncestorClosures;
         private final List<String> subtreeIds;
         private final List<String> externalAncestorIds;
+        private final String targetAncestorId;
+        private final int targetAncestorCount;
         private final long targetRootDepth;
 
-        ClosureMoveSnapshot(List<FileClosureRecord> subtreeClosures, List<FileClosureRecord> targetAncestorClosures,
-                List<String> subtreeIds, List<String> externalAncestorIds, long targetRootDepth) {
-            this.subtreeClosures = subtreeClosures;
-            this.targetAncestorClosures = targetAncestorClosures;
+        ClosureMoveSnapshot(List<String> subtreeIds, List<String> externalAncestorIds, String targetAncestorId,
+                int targetAncestorCount, long targetRootDepth) {
             this.subtreeIds = subtreeIds;
             this.externalAncestorIds = externalAncestorIds;
+            this.targetAncestorId = targetAncestorId;
+            this.targetAncestorCount = targetAncestorCount;
             this.targetRootDepth = targetRootDepth;
-        }
-    }
-
-    private void assertBatchSucceeded(int[] results, int expectedSize, String message) {
-        if(results.length != expectedSize) {
-            throw new IllegalStateException(message);
-        }
-        for (int result : results) {
-            if(result != 1 && result != Statement.SUCCESS_NO_INFO) {
-                throw new IllegalStateException(message);
-            }
         }
     }
 

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -501,7 +501,7 @@ public class FileRepo implements BaseRepo {
         DSLContext dsl = db(shardingKey);
         ClosureMoveSnapshot snapshot = loadClosureMoveSnapshot(dsl, fileId, targetAncestorId);
 
-        deleteExternalClosures(dsl, snapshot, fileId);
+        deleteExternalClosures(dsl, snapshot);
         insertExternalClosures(dsl, snapshot, fileId);
         updateSubtreeRootDepths(dsl, snapshot, fileId);
     }
@@ -558,17 +558,12 @@ public class FileRepo implements BaseRepo {
                 targetAncestorClosures.size(), targetSelfClosure.getRootDepth());
     }
 
-    private void deleteExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
-        int expectedDeleteCount = snapshot.externalAncestorIds.size() * snapshot.subtreeIds.size();
-        int deletedCount = 0;
+    private void deleteExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot) {
         if(!snapshot.externalAncestorIds.isEmpty()) {
-            deletedCount = dsl.delete(FILE_CLOSURE)
+            dsl.delete(FILE_CLOSURE)
                     .where(FILE_CLOSURE.ANCESTOR_ID.in(snapshot.externalAncestorIds))
                     .and(FILE_CLOSURE.DESCENDANT_ID.in(snapshot.subtreeIds))
                     .execute();
-        }
-        if(deletedCount != expectedDeleteCount) {
-            throw new IllegalStateException("delete external file_closure failed, fileId: " + fileId);
         }
     }
 

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -8,6 +8,7 @@ import static com.ke.bella.files.db.Tables.FILE_SHARDING;
 import static com.ke.bella.files.db.repo.DSLContextHolder.targetTableName;
 import static org.jooq.impl.DSL.field;
 
+import java.sql.Statement;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.InsertSetMoreStep;
+import org.jooq.Query;
 import org.jooq.Record;
 import org.jooq.Record1;
 import org.jooq.Record3;
@@ -480,6 +482,105 @@ public class FileRepo implements BaseRepo {
                 .where(FILE_CLOSURE.DESCENDANT_ID.eq(fileId))
                 .or(FILE_CLOSURE.ANCESTOR_ID.eq(fileId))
                 .execute();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void moveFileClosures(String fileId, String targetAncestorId) {
+        String shardingKey = getShardingKeyByFileId(fileId);
+        DSLContext dsl = db(shardingKey);
+
+        List<FileClosureRecord> subtreeClosures = dsl.selectFrom(FILE_CLOSURE)
+                .where(FILE_CLOSURE.ANCESTOR_ID.eq(fileId))
+                .orderBy(FILE_CLOSURE.DEPTH.asc())
+                .forUpdate()
+                .fetchInto(FileClosureRecord.class);
+        Assert.isTrue(!CollectionUtils.isEmpty(subtreeClosures),
+                "ancestor_id not found in file_closure, ancestor_id: " + fileId);
+        boolean sourceSelfClosureExists = subtreeClosures.stream()
+                .anyMatch(closure -> StringUtils.equals(closure.getDescendantId(), fileId) && closure.getDepth() == 0L);
+        Assert.isTrue(sourceSelfClosureExists, "self closure not found, fileId: " + fileId);
+
+        boolean targetInSubtree = subtreeClosures.stream()
+                .anyMatch(closure -> StringUtils.equals(closure.getDescendantId(), targetAncestorId));
+        Assert.isTrue(!targetInSubtree, "cannot move a directory into itself or its descendant");
+
+        List<FileClosureRecord> sourceAncestorClosures = dsl.selectFrom(FILE_CLOSURE)
+                .where(FILE_CLOSURE.DESCENDANT_ID.eq(fileId))
+                .orderBy(FILE_CLOSURE.DEPTH.asc())
+                .forUpdate()
+                .fetchInto(FileClosureRecord.class);
+        Assert.isTrue(!CollectionUtils.isEmpty(sourceAncestorClosures),
+                "descendant_id not found in file_closure, descendant_id: " + fileId);
+
+        List<FileClosureRecord> targetAncestorClosures = dsl.selectFrom(FILE_CLOSURE)
+                .where(FILE_CLOSURE.DESCENDANT_ID.eq(targetAncestorId))
+                .orderBy(FILE_CLOSURE.DEPTH.asc())
+                .forUpdate()
+                .fetchInto(FileClosureRecord.class);
+        Assert.isTrue(!CollectionUtils.isEmpty(targetAncestorClosures),
+                "descendant_id not found in file_closure, descendant_id: " + targetAncestorId);
+
+        FileClosureRecord targetSelfClosure = targetAncestorClosures.stream()
+                .filter(closure -> closure.getDepth() == 0L)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "self closure not found, descendant_id: " + targetAncestorId));
+        Assert.isTrue(targetSelfClosure.getRootDepth() > 0,
+                "invalid root_depth for target ancestor, descendant_id: " + targetAncestorId);
+
+        List<String> subtreeIds = subtreeClosures.stream()
+                .map(FileClosureRecord::getDescendantId)
+                .collect(Collectors.toList());
+        List<String> externalAncestorIds = sourceAncestorClosures.stream()
+                .map(FileClosureRecord::getAncestorId)
+                .filter(ancestorId -> !StringUtils.equals(ancestorId, fileId))
+                .collect(Collectors.toList());
+
+        int expectedDeleteCount = externalAncestorIds.size() * subtreeIds.size();
+        int deletedCount = 0;
+        if(!externalAncestorIds.isEmpty()) {
+            deletedCount = dsl.delete(FILE_CLOSURE)
+                    .where(FILE_CLOSURE.ANCESTOR_ID.in(externalAncestorIds))
+                    .and(FILE_CLOSURE.DESCENDANT_ID.in(subtreeIds))
+                    .execute();
+        }
+        if(deletedCount != expectedDeleteCount) {
+            throw new IllegalStateException("delete external file_closure failed, fileId: " + fileId);
+        }
+
+        List<InsertSetMoreStep<FileClosureRecord>> inserts = new ArrayList<>();
+        for (FileClosureRecord targetAncestorClosure : targetAncestorClosures) {
+            for (FileClosureRecord subtreeClosure : subtreeClosures) {
+                long depth = targetAncestorClosure.getDepth() + 1 + subtreeClosure.getDepth();
+                inserts.add(createFileClosureInsert(dsl, subtreeClosure.getDescendantId(),
+                        targetAncestorClosure.getAncestorId(), depth));
+            }
+        }
+        assertBatchSucceeded(dsl.batch(inserts).execute(), inserts.size(),
+                "batch insert moved file_closure failed, fileId: " + fileId);
+
+        List<Query> rootDepthUpdates = new ArrayList<>();
+        for (FileClosureRecord subtreeClosure : subtreeClosures) {
+            long rootDepth = targetSelfClosure.getRootDepth() + 1 + subtreeClosure.getDepth();
+            rootDepthUpdates.add(dsl.update(FILE_CLOSURE)
+                    .set(FILE_CLOSURE.ROOT_DEPTH, rootDepth)
+                    .where(FILE_CLOSURE.ANCESTOR_ID.eq(subtreeClosure.getDescendantId()))
+                    .and(FILE_CLOSURE.DESCENDANT_ID.eq(subtreeClosure.getDescendantId()))
+                    .and(FILE_CLOSURE.DEPTH.eq(0L)));
+        }
+        assertBatchSucceeded(dsl.batch(rootDepthUpdates).execute(), rootDepthUpdates.size(),
+                "batch update file_closure root_depth failed, fileId: " + fileId);
+    }
+
+    private void assertBatchSucceeded(int[] results, int expectedSize, String message) {
+        if(results.length != expectedSize) {
+            throw new IllegalStateException(message);
+        }
+        for (int result : results) {
+            if(result != 1 && result != Statement.SUCCESS_NO_INFO) {
+                throw new IllegalStateException(message);
+            }
+        }
     }
 
     public List<FileDB> findFiles(String spaceCode, String ancestorId) {

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -453,10 +453,7 @@ public class FileRepo implements BaseRepo {
         long rootDepth = 1L;
 
         if(StringUtils.isNotEmpty(ancestorId)) {
-            List<FileClosureRecord> ancestorClosures = dsl.selectFrom(FILE_CLOSURE)
-                    .where(FILE_CLOSURE.DESCENDANT_ID.eq(ancestorId))
-                    .orderBy(FILE_CLOSURE.DEPTH.asc())
-                    .fetchInto(FileClosureRecord.class);
+            List<FileClosureRecord> ancestorClosures = loadAncestorClosuresForUpdate(dsl, ancestorId);
 
             Assert.isTrue(!CollectionUtils.isEmpty(ancestorClosures),
                     "descendant_id not found in file_closure, descendant_id: " + ancestorId);
@@ -474,6 +471,19 @@ public class FileRepo implements BaseRepo {
         if(results.length != inserts.size()) {
             throw new IllegalStateException("batch insert file_closure failed, fileId: " + fileId);
         }
+    }
+
+    private List<FileClosureRecord> loadAncestorClosuresForUpdate(DSLContext dsl, String ancestorId) {
+        dsl.select(FILE_CLOSURE.ID)
+                .from(FILE_CLOSURE)
+                .where(FILE_CLOSURE.DESCENDANT_ID.eq(ancestorId))
+                .forUpdate()
+                .fetch();
+        return dsl.selectFrom(FILE_CLOSURE)
+                .where(FILE_CLOSURE.DESCENDANT_ID.eq(ancestorId))
+                .orderBy(FILE_CLOSURE.DEPTH.asc())
+                .forUpdate()
+                .fetchInto(FileClosureRecord.class);
     }
 
     public void deleteFileClosure(String fileId, FileType fileType) {

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -488,7 +488,14 @@ public class FileRepo implements BaseRepo {
     public void moveFileClosures(String fileId, String targetAncestorId) {
         String shardingKey = getShardingKeyByFileId(fileId);
         DSLContext dsl = db(shardingKey);
+        ClosureMoveSnapshot snapshot = loadClosureMoveSnapshot(dsl, fileId, targetAncestorId);
 
+        deleteExternalClosures(dsl, snapshot, fileId);
+        insertExternalClosures(dsl, snapshot, fileId);
+        updateSubtreeRootDepths(dsl, snapshot, fileId);
+    }
+
+    private ClosureMoveSnapshot loadClosureMoveSnapshot(DSLContext dsl, String fileId, String targetAncestorId) {
         List<FileClosureRecord> subtreeClosures = dsl.selectFrom(FILE_CLOSURE)
                 .where(FILE_CLOSURE.ANCESTOR_ID.eq(fileId))
                 .orderBy(FILE_CLOSURE.DEPTH.asc())
@@ -536,21 +543,28 @@ public class FileRepo implements BaseRepo {
                 .filter(ancestorId -> !StringUtils.equals(ancestorId, fileId))
                 .collect(Collectors.toList());
 
-        int expectedDeleteCount = externalAncestorIds.size() * subtreeIds.size();
+        return new ClosureMoveSnapshot(subtreeClosures, targetAncestorClosures, subtreeIds,
+                externalAncestorIds, targetSelfClosure.getRootDepth());
+    }
+
+    private void deleteExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
+        int expectedDeleteCount = snapshot.externalAncestorIds.size() * snapshot.subtreeIds.size();
         int deletedCount = 0;
-        if(!externalAncestorIds.isEmpty()) {
+        if(!snapshot.externalAncestorIds.isEmpty()) {
             deletedCount = dsl.delete(FILE_CLOSURE)
-                    .where(FILE_CLOSURE.ANCESTOR_ID.in(externalAncestorIds))
-                    .and(FILE_CLOSURE.DESCENDANT_ID.in(subtreeIds))
+                    .where(FILE_CLOSURE.ANCESTOR_ID.in(snapshot.externalAncestorIds))
+                    .and(FILE_CLOSURE.DESCENDANT_ID.in(snapshot.subtreeIds))
                     .execute();
         }
         if(deletedCount != expectedDeleteCount) {
             throw new IllegalStateException("delete external file_closure failed, fileId: " + fileId);
         }
+    }
 
+    private void insertExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
         List<InsertSetMoreStep<FileClosureRecord>> inserts = new ArrayList<>();
-        for (FileClosureRecord targetAncestorClosure : targetAncestorClosures) {
-            for (FileClosureRecord subtreeClosure : subtreeClosures) {
+        for (FileClosureRecord targetAncestorClosure : snapshot.targetAncestorClosures) {
+            for (FileClosureRecord subtreeClosure : snapshot.subtreeClosures) {
                 long depth = targetAncestorClosure.getDepth() + 1 + subtreeClosure.getDepth();
                 inserts.add(createFileClosureInsert(dsl, subtreeClosure.getDescendantId(),
                         targetAncestorClosure.getAncestorId(), depth));
@@ -558,10 +572,12 @@ public class FileRepo implements BaseRepo {
         }
         assertBatchSucceeded(dsl.batch(inserts).execute(), inserts.size(),
                 "batch insert moved file_closure failed, fileId: " + fileId);
+    }
 
+    private void updateSubtreeRootDepths(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
         List<Query> rootDepthUpdates = new ArrayList<>();
-        for (FileClosureRecord subtreeClosure : subtreeClosures) {
-            long rootDepth = targetSelfClosure.getRootDepth() + 1 + subtreeClosure.getDepth();
+        for (FileClosureRecord subtreeClosure : snapshot.subtreeClosures) {
+            long rootDepth = snapshot.targetRootDepth + 1 + subtreeClosure.getDepth();
             rootDepthUpdates.add(dsl.update(FILE_CLOSURE)
                     .set(FILE_CLOSURE.ROOT_DEPTH, rootDepth)
                     .where(FILE_CLOSURE.ANCESTOR_ID.eq(subtreeClosure.getDescendantId()))
@@ -570,6 +586,23 @@ public class FileRepo implements BaseRepo {
         }
         assertBatchSucceeded(dsl.batch(rootDepthUpdates).execute(), rootDepthUpdates.size(),
                 "batch update file_closure root_depth failed, fileId: " + fileId);
+    }
+
+    private static class ClosureMoveSnapshot {
+        private final List<FileClosureRecord> subtreeClosures;
+        private final List<FileClosureRecord> targetAncestorClosures;
+        private final List<String> subtreeIds;
+        private final List<String> externalAncestorIds;
+        private final long targetRootDepth;
+
+        ClosureMoveSnapshot(List<FileClosureRecord> subtreeClosures, List<FileClosureRecord> targetAncestorClosures,
+                List<String> subtreeIds, List<String> externalAncestorIds, long targetRootDepth) {
+            this.subtreeClosures = subtreeClosures;
+            this.targetAncestorClosures = targetAncestorClosures;
+            this.subtreeIds = subtreeIds;
+            this.externalAncestorIds = externalAncestorIds;
+            this.targetRootDepth = targetRootDepth;
+        }
     }
 
     private void assertBatchSucceeded(int[] results, int expectedSize, String message) {

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -688,11 +688,7 @@ public class FileService {
 
     @Transactional(rollbackFor = Exception.class)
     public OpenAIFile moveFile(String fileId, String targetAncestorId) {
-
-        // 执行移动操作
-        FileType fileType = FileType.fromFileId(fileId);
-        fileRepo.deleteFileClosure(fileId, fileType);
-        fileRepo.addFileClosures(fileId, targetAncestorId);
+        fileRepo.moveFileClosures(fileId, targetAncestorId);
 
         FileOps ops = FileOps.builder()
                 .fileId(fileId)

--- a/api/src/main/java/com/ke/bella/files/service/lock/FileUniquenessLock.java
+++ b/api/src/main/java/com/ke/bella/files/service/lock/FileUniquenessLock.java
@@ -10,4 +10,7 @@ public interface FileUniquenessLock {
 
     <T> T executeWithLock(String spaceCode, String ancestorId, String filename,
             long timeoutMs, Supplier<T> action);
+
+    <T> T executeWithMoveLock(String spaceCode, boolean directory,
+            long timeoutMs, Supplier<T> action);
 }

--- a/api/src/main/java/com/ke/bella/files/service/lock/RedisFileUniquenessLock.java
+++ b/api/src/main/java/com/ke/bella/files/service/lock/RedisFileUniquenessLock.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.redisson.api.RLock;
+import org.redisson.api.RReadWriteLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RedisFileUniquenessLock implements FileUniquenessLock {
 
     private static final String LOCK_PREFIX = "file-api:file:uniqueness:";
+    private static final String MOVE_LOCK_PREFIX = "file-api:file:move:";
 
     @Autowired
     private RedissonClient redissonClient;
@@ -90,6 +92,38 @@ public class RedisFileUniquenessLock implements FileUniquenessLock {
             if(lock.isHeldByCurrentThread()) {
                 lock.unlock();
                 LOGGER.debug("Released lock in executeWithLock finally block: {}, filename: {}", key, filename);
+            }
+        }
+    }
+
+    @Override
+    public <T> T executeWithMoveLock(String spaceCode, boolean directory,
+            long timeoutMs, Supplier<T> action) {
+        String key = MOVE_LOCK_PREFIX + spaceCode;
+        RReadWriteLock readWriteLock = redissonClient.getReadWriteLock(key);
+        RLock lock = directory ? readWriteLock.writeLock() : readWriteLock.readLock();
+
+        try {
+            boolean lockAcquired = lock.tryLock(timeoutMs, TimeUnit.MILLISECONDS);
+            if(!lockAcquired) {
+                LOGGER.warn("File move conflict detected for space lock: {}", key);
+                throw new IllegalStateException(
+                        String.format("Space '%s' has another file move in progress, please try again later", spaceCode));
+            }
+
+            LOGGER.debug("Successfully acquired {} move lock: {}", directory ? "directory" : "file", key);
+            return action.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Interrupted while acquiring move lock: {}", key, e);
+            throw new IllegalStateException("Move lock acquisition interrupted", e);
+        } catch (Exception e) {
+            LOGGER.error("Error in executeWithMoveLock for key: {}", key, e);
+            throw e;
+        } finally {
+            if(lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                LOGGER.debug("Released move lock: {}", key);
             }
         }
     }

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
@@ -102,6 +102,115 @@ public class FileControllerMoveTest {
     }
 
     @Test
+    public void move_DirectorySuccess() throws Exception {
+        String ancestorId = "anc-1";
+        String spaceCode = "sp-a";
+        String fileId = "dir-1";
+
+        FileDB ancestor = buildFile(ancestorId, "target", true, spaceCode);
+        FileDB source = buildFile(fileId, "source", true, spaceCode);
+
+        when(fileService.getFile0(ancestorId)).thenReturn(ancestor);
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq(ancestorId), eq("source"), anyLong(), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(4);
+                    return supplier.get();
+                });
+        when(fileService.moveFile(fileId, ancestorId)).thenReturn(OpenAIFile.builder()
+                .id(fileId)
+                .filename("source")
+                .spaceCode(spaceCode)
+                .build());
+
+        String body = "{\"file_id\":\"" + fileId + "\",\"ancestor_id\":\"" + ancestorId + "\"}";
+
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(fileId));
+
+        verify(fileService).moveFile(fileId, ancestorId);
+    }
+
+    @Test
+    public void move_CurrentDirectoryCheckedInsideLock() throws Exception {
+        String ancestorId = "anc-1";
+        String spaceCode = "sp-a";
+        String fileId = "dir-1";
+        FileDB ancestor = buildFile(ancestorId, "target", true, spaceCode);
+        FileDB source = buildFile(fileId, "source", true, spaceCode);
+
+        when(fileService.getFile0(ancestorId)).thenReturn(ancestor);
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileService.getDirectAncestorId(fileId)).thenReturn(ancestorId);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq(ancestorId), eq("source"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+
+        String body = "{\"file_id\":\"" + fileId + "\",\"ancestor_id\":\"" + ancestorId + "\"}";
+
+        BellaContext.setOperator(Operator.builder().spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("file already in target directory"));
+
+        verify(fileService, never()).moveFile(any(), any());
+    }
+
+    @Test
+    public void move_DuplicateNameCheckedInsideLock() throws Exception {
+        String ancestorId = "anc-1";
+        String spaceCode = "sp-a";
+        String fileId = "dir-1";
+        FileDB ancestor = buildFile(ancestorId, "target", true, spaceCode);
+        FileDB source = buildFile(fileId, "source", true, spaceCode);
+
+        when(fileService.getFile0(ancestorId)).thenReturn(ancestor);
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileService.exists(spaceCode, ancestorId, "source")).thenReturn(true);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq(ancestorId), eq("source"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+
+        String body = "{\"file_id\":\"" + fileId + "\",\"ancestor_id\":\"" + ancestorId + "\"}";
+
+        BellaContext.setOperator(Operator.builder().spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("filename already exists"));
+
+        verify(fileService, never()).moveFile(any(), any());
+    }
+
+    @Test
+    public void move_CrossSpaceRejected() throws Exception {
+        String ancestorId = "anc-1";
+        String fileId = "dir-1";
+        when(fileService.getFile0(ancestorId)).thenReturn(buildFile(ancestorId, "target", true, "sp-a"));
+        when(fileService.getFile0(fileId)).thenReturn(buildFile(fileId, "source", true, "sp-b"));
+
+        String body = "{\"file_id\":\"" + fileId + "\",\"ancestor_id\":\"" + ancestorId + "\"}";
+
+        BellaContext.setOperator(Operator.builder().spaceCode("sp-a").build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", "sp-a")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("space mismatch for file_id and ancestor_id"));
+
+        verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
+    }
+
+    @Test
     public void move_FileNotFound() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
@@ -63,7 +63,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_Success() throws Exception {
+    public void moveSuccess() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "f-1";
@@ -102,7 +102,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_DirectorySuccess() throws Exception {
+    public void moveDirectorySuccess() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "dir-1";
@@ -137,7 +137,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_CurrentDirectoryCheckedInsideLock() throws Exception {
+    public void moveCurrentDirectoryCheckedInsideLock() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "dir-1";
@@ -164,7 +164,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_DuplicateNameCheckedInsideLock() throws Exception {
+    public void moveDuplicateNameCheckedInsideLock() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "dir-1";
@@ -191,7 +191,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_CrossSpaceRejected() throws Exception {
+    public void moveCrossSpaceRejected() throws Exception {
         String ancestorId = "anc-1";
         String fileId = "dir-1";
         when(fileService.getFile0(ancestorId)).thenReturn(buildFile(ancestorId, "target", true, "sp-a"));
@@ -211,7 +211,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_FileNotFound() throws Exception {
+    public void moveFileNotFound() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "missing";
@@ -234,7 +234,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_LockConflict() throws Exception {
+    public void moveLockConflict() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "f-1";
@@ -258,7 +258,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_InvalidAncestorId() throws Exception {
+    public void moveInvalidAncestorId() throws Exception {
         String ancestorId = "invalid-anc";
         when(fileService.getFile0(ancestorId)).thenReturn(null);
 
@@ -274,7 +274,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_AncestorIsNotDir() throws Exception {
+    public void moveAncestorIsNotDir() throws Exception {
         String ancestorId = "anc-1";
         FileDB ancestor = buildFile(ancestorId, "anc", false, "sp-a");
         when(fileService.getFile0(ancestorId)).thenReturn(ancestor);
@@ -291,7 +291,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_ServiceThrowsIllegalArgument() throws Exception {
+    public void moveServiceThrowsIllegalArgument() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
         String fileId = "f-1";
@@ -321,7 +321,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_MissingFileId_BadRequest() throws Exception {
+    public void moveMissingFileIdBadRequest() throws Exception {
         String body = "{\"ancestor_id\":\"anc-1\"}";
 
         BellaContext.setOperator(Operator.builder().spaceCode("sp-a").build());
@@ -334,7 +334,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_MissingAncestorId_BadRequest() throws Exception {
+    public void moveMissingAncestorIdBadRequest() throws Exception {
         String body = "{\"file_id\":\"f-1\"}";
 
         BellaContext.setOperator(Operator.builder().spaceCode("sp-a").build());
@@ -347,7 +347,7 @@ public class FileControllerMoveTest {
     }
 
     @Test
-    public void move_NullRequestBody_InternalServerError() throws Exception {
+    public void moveNullRequestBodyInternalServerError() throws Exception {
         BellaContext.setOperator(Operator.builder().spaceCode("sp-a").build());
         mockMvc.perform(post("/v1/files/move")
                 .header("X-BELLA-SPACE-CODE", "sp-a")

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
@@ -1,6 +1,7 @@
 package com.ke.bella.files.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -45,6 +46,8 @@ public class FileControllerMoveTest {
 
         ReflectionTestUtils.setField(fileController, "fileService", fileService);
         ReflectionTestUtils.setField(fileController, "fl", fileUniquenessLock);
+        when(fileUniquenessLock.executeWithMoveLock(any(), anyBoolean(), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(3)).get());
 
         mockMvc = MockMvcBuilders
                 .standaloneSetup(fileController)
@@ -98,6 +101,7 @@ public class FileControllerMoveTest {
                 .andExpect(jsonPath("$.filename").value("name.txt"))
                 .andExpect(jsonPath("$.spaceCode").value(spaceCode));
 
+        verify(fileUniquenessLock).executeWithMoveLock(eq(spaceCode), eq(false), anyLong(), any());
         verify(fileService).moveFile(fileId, ancestorId);
     }
 
@@ -133,6 +137,7 @@ public class FileControllerMoveTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(fileId));
 
+        verify(fileUniquenessLock).executeWithMoveLock(eq(spaceCode), eq(true), anyLong(), any());
         verify(fileService).moveFile(fileId, ancestorId);
     }
 

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -43,8 +43,8 @@ public class FileRepoMoveTest {
 
     @BeforeClass
     public static void setupConnection() throws Exception {
-        connection = DriverManager.getConnection("jdbc:h2:mem:fileRepoMove;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "");
-        dsl = DSL.using(connection, SQLDialect.MYSQL);
+        connection = DriverManager.getConnection("jdbc:h2:mem:fileRepoMove;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1", "sa", "");
+        dsl = DSL.using(connection, SQLDialect.H2);
         fileRepo = new FileRepo(dsl);
     }
 

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -86,6 +86,19 @@ public class FileRepoMoveTest {
     }
 
     @Test
+    public void moveDirectoryAllowsMissingExternalClosureRows() {
+        dsl.execute("delete from file_closure_0 where ancestor_id = ? and descendant_id = ?", OLD_ROOT, LEAF);
+
+        fileRepo.moveFileClosures(SOURCE, TARGET);
+
+        assertFalse(hasClosure(OLD_ROOT, SOURCE));
+        assertFalse(hasClosure(OLD_ROOT, CHILD));
+        assertFalse(hasClosure(OLD_ROOT, LEAF));
+        assertClosure(TARGET, LEAF, 3L, -1L);
+        assertClosure(LEAF, LEAF, 0L, 5L);
+    }
+
+    @Test
     public void movedSubtreeIsVisibleThroughHierarchyQueries() {
         fileRepo.moveFileClosures(SOURCE, TARGET);
 

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -1,0 +1,184 @@
+package com.ke.bella.files.db.repo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ke.bella.openapi.BellaContext;
+import com.ke.bella.openapi.Operator;
+
+public class FileRepoMoveTest {
+    private static final String OLD_ROOT = "file-old-0-d";
+    private static final String SOURCE = "file-source-0-d";
+    private static final String CHILD = "file-child-0-d";
+    private static final String LEAF = "file-leaf-0";
+    private static final String NEW_ROOT = "file-new-root-0-d";
+    private static final String TARGET = "file-target-0-d";
+
+    private static Connection connection;
+    private static DSLContext dsl;
+    private static FileRepo fileRepo;
+
+    @BeforeClass
+    public static void setupConnection() throws Exception {
+        connection = DriverManager.getConnection("jdbc:h2:mem:fileRepoMove;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "");
+        dsl = DSL.using(connection, SQLDialect.MYSQL);
+        fileRepo = new FileRepo(dsl);
+    }
+
+    @Before
+    public void setup() {
+        dsl.execute("drop table if exists file_closure_0");
+        dsl.execute("create table file_closure_0 ("
+                + "id bigint auto_increment primary key,"
+                + "ancestor_id varchar(255) not null,"
+                + "descendant_id varchar(255) not null,"
+                + "space_code varchar(128) not null default '',"
+                + "depth bigint not null default 0,"
+                + "root_depth bigint not null default -1,"
+                + "cuid bigint not null default 0,"
+                + "cu_name varchar(32) not null default '',"
+                + "ctime timestamp not null default current_timestamp,"
+                + "muid bigint not null default 0,"
+                + "mu_name varchar(32) not null default '',"
+                + "mtime timestamp not null default current_timestamp,"
+                + "unique (ancestor_id, descendant_id))");
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+        insertTree();
+    }
+
+    @AfterClass
+    public static void tearDownConnection() throws Exception {
+        connection.close();
+    }
+
+    @Test
+    public void moveDirectoryPreservesSubtreeAndReplacesExternalAncestors() {
+        fileRepo.moveFileClosures(SOURCE, TARGET);
+
+        assertFalse(hasClosure(OLD_ROOT, SOURCE));
+        assertFalse(hasClosure(OLD_ROOT, CHILD));
+        assertFalse(hasClosure(OLD_ROOT, LEAF));
+
+        assertClosure(SOURCE, CHILD, 1L, -1L);
+        assertClosure(SOURCE, LEAF, 2L, -1L);
+        assertClosure(CHILD, LEAF, 1L, -1L);
+
+        assertClosure(TARGET, SOURCE, 1L, -1L);
+        assertClosure(TARGET, CHILD, 2L, -1L);
+        assertClosure(TARGET, LEAF, 3L, -1L);
+        assertClosure(NEW_ROOT, SOURCE, 2L, -1L);
+        assertClosure(NEW_ROOT, CHILD, 3L, -1L);
+        assertClosure(NEW_ROOT, LEAF, 4L, -1L);
+
+        assertClosure(SOURCE, SOURCE, 0L, 3L);
+        assertClosure(CHILD, CHILD, 0L, 4L);
+        assertClosure(LEAF, LEAF, 0L, 5L);
+    }
+
+    @Test
+    public void moveLeafUsesSameSubtreeAlgorithm() {
+        fileRepo.moveFileClosures(LEAF, TARGET);
+
+        assertFalse(hasClosure(OLD_ROOT, LEAF));
+        assertFalse(hasClosure(SOURCE, LEAF));
+        assertFalse(hasClosure(CHILD, LEAF));
+        assertClosure(TARGET, LEAF, 1L, -1L);
+        assertClosure(NEW_ROOT, LEAF, 2L, -1L);
+        assertClosure(LEAF, LEAF, 0L, 3L);
+    }
+
+    @Test
+    public void failedBatchCanRollBackAllClosureChanges() throws Exception {
+        insertClosure(NEW_ROOT, CHILD, 99L, -1L);
+        Map<String, String> before = snapshot();
+
+        connection.setAutoCommit(false);
+        try {
+            assertThrows(RuntimeException.class, () -> fileRepo.moveFileClosures(SOURCE, TARGET));
+            connection.rollback();
+            assertEquals(before, snapshot());
+        } finally {
+            connection.setAutoCommit(true);
+        }
+    }
+
+    @Test
+    public void movingToSelfOrDescendantDoesNotChangeClosures() {
+        Map<String, String> before = snapshot();
+
+        IllegalArgumentException selfError = assertThrows(IllegalArgumentException.class,
+                () -> fileRepo.moveFileClosures(SOURCE, SOURCE));
+        assertTrue(selfError.getMessage().contains("cannot move a directory"));
+        assertEquals(before, snapshot());
+
+        assertThrows(IllegalArgumentException.class, () -> fileRepo.moveFileClosures(SOURCE, CHILD));
+        assertEquals(before, snapshot());
+
+        assertThrows(IllegalArgumentException.class, () -> fileRepo.moveFileClosures(SOURCE, LEAF));
+        assertEquals(before, snapshot());
+    }
+
+    private void insertTree() {
+        insertClosure(OLD_ROOT, OLD_ROOT, 0L, 1L);
+        insertClosure(SOURCE, SOURCE, 0L, 2L);
+        insertClosure(OLD_ROOT, SOURCE, 1L, -1L);
+        insertClosure(CHILD, CHILD, 0L, 3L);
+        insertClosure(SOURCE, CHILD, 1L, -1L);
+        insertClosure(OLD_ROOT, CHILD, 2L, -1L);
+        insertClosure(LEAF, LEAF, 0L, 4L);
+        insertClosure(CHILD, LEAF, 1L, -1L);
+        insertClosure(SOURCE, LEAF, 2L, -1L);
+        insertClosure(OLD_ROOT, LEAF, 3L, -1L);
+        insertClosure(NEW_ROOT, NEW_ROOT, 0L, 1L);
+        insertClosure(TARGET, TARGET, 0L, 2L);
+        insertClosure(NEW_ROOT, TARGET, 1L, -1L);
+    }
+
+    private void insertClosure(String ancestorId, String descendantId, long depth, long rootDepth) {
+        dsl.execute("insert into file_closure_0 "
+                        + "(ancestor_id, descendant_id, space_code, depth, root_depth) values (?, ?, ?, ?, ?)",
+                ancestorId, descendantId, "sp-a", depth, rootDepth);
+    }
+
+    private boolean hasClosure(String ancestorId, String descendantId) {
+        return dsl.fetchExists(DSL.selectOne()
+                .from(DSL.table("file_closure_0"))
+                .where(DSL.field("ancestor_id").eq(ancestorId))
+                .and(DSL.field("descendant_id").eq(descendantId)));
+    }
+
+    private void assertClosure(String ancestorId, String descendantId, long depth, long rootDepth) {
+        Record record = dsl.fetchOne("select depth, root_depth from file_closure_0 where ancestor_id = ? and descendant_id = ?",
+                ancestorId, descendantId);
+        assertEquals(depth, record.get(0, Long.class).longValue());
+        assertEquals(rootDepth, record.get(1, Long.class).longValue());
+    }
+
+    private Map<String, String> snapshot() {
+        Result<Record> records = dsl.fetch("select ancestor_id, descendant_id, depth, root_depth "
+                + "from file_closure_0 order by ancestor_id, descendant_id");
+        Map<String, String> snapshot = new LinkedHashMap<>();
+        for (Record record : records) {
+            String key = record.get(0, String.class) + "->" + record.get(1, String.class);
+            snapshot.put(key, record.get(2, Long.class) + ":" + record.get(3, Long.class));
+        }
+        return snapshot;
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -50,63 +50,10 @@ public class FileRepoMoveTest {
 
     @Before
     public void setup() {
-        dsl.execute("drop table if exists file_closure_0");
-        dsl.execute("drop table if exists file_0");
-        createFileClosureTable();
-        createFileTable();
+        FileRepoTestFixture.recreateUserFileTables(dsl, "0");
         BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-0").build());
         insertTree();
         insertFiles();
-    }
-
-    private void createFileClosureTable() {
-        dsl.execute("create table file_closure_0 ("
-                + "id bigint auto_increment primary key,"
-                + "ancestor_id varchar(255) not null,"
-                + "descendant_id varchar(255) not null,"
-                + "space_code varchar(128) not null default '',"
-                + "depth bigint not null default 0,"
-                + "root_depth bigint not null default -1,"
-                + "cuid bigint not null default 0,"
-                + "cu_name varchar(32) not null default '',"
-                + "ctime timestamp not null default current_timestamp,"
-                + "muid bigint not null default 0,"
-                + "mu_name varchar(32) not null default '',"
-                + "mtime timestamp not null default current_timestamp,"
-                + "unique (ancestor_id, descendant_id))");
-    }
-
-    private void createFileTable() {
-        dsl.execute("create table file_0 ("
-                + "id bigint auto_increment primary key,"
-                + "file_id varchar(256) not null,"
-                + "version bigint not null default 0,"
-                + "filename varchar(512) not null default '',"
-                + "is_dir int not null default 0,"
-                + "extension varchar(512) not null default '',"
-                + "mime_type varchar(512) not null default '',"
-                + "type varchar(512) not null default '',"
-                + "bucket varchar(256) not null default '',"
-                + "path varchar(512) not null default '',"
-                + "bytes bigint not null default 0,"
-                + "space_code varchar(128) not null default '',"
-                + "purpose varchar(64) not null default '',"
-                + "cuid bigint not null default 0,"
-                + "cu_name varchar(32) not null default '',"
-                + "ctime timestamp not null default current_timestamp,"
-                + "muid bigint not null default 0,"
-                + "mu_name varchar(32) not null default '',"
-                + "mtime timestamp not null default current_timestamp,"
-                + "meta_data clob,"
-                + "status int not null default 0,"
-                + "ak_code varchar(128) not null default '',"
-                + "broadcast_status bigint not null default 0,"
-                + "dom_tree_file_id varchar(256) not null default '',"
-                + "pdf_file_id varchar(256) not null default '',"
-                + "description varchar(256) not null default '',"
-                + "cities varchar(512) not null default '',"
-                + "tags varchar(512) not null default '',"
-                + "unique (file_id, space_code))");
     }
 
     @AfterClass

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -7,8 +7,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -20,6 +24,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.openapi.BellaContext;
 import com.ke.bella.openapi.Operator;
 
@@ -45,6 +51,15 @@ public class FileRepoMoveTest {
     @Before
     public void setup() {
         dsl.execute("drop table if exists file_closure_0");
+        dsl.execute("drop table if exists file_0");
+        createFileClosureTable();
+        createFileTable();
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-0").build());
+        insertTree();
+        insertFiles();
+    }
+
+    private void createFileClosureTable() {
         dsl.execute("create table file_closure_0 ("
                 + "id bigint auto_increment primary key,"
                 + "ancestor_id varchar(255) not null,"
@@ -59,8 +74,39 @@ public class FileRepoMoveTest {
                 + "mu_name varchar(32) not null default '',"
                 + "mtime timestamp not null default current_timestamp,"
                 + "unique (ancestor_id, descendant_id))");
-        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
-        insertTree();
+    }
+
+    private void createFileTable() {
+        dsl.execute("create table file_0 ("
+                + "id bigint auto_increment primary key,"
+                + "file_id varchar(256) not null,"
+                + "version bigint not null default 0,"
+                + "filename varchar(512) not null default '',"
+                + "is_dir int not null default 0,"
+                + "extension varchar(512) not null default '',"
+                + "mime_type varchar(512) not null default '',"
+                + "type varchar(512) not null default '',"
+                + "bucket varchar(256) not null default '',"
+                + "path varchar(512) not null default '',"
+                + "bytes bigint not null default 0,"
+                + "space_code varchar(128) not null default '',"
+                + "purpose varchar(64) not null default '',"
+                + "cuid bigint not null default 0,"
+                + "cu_name varchar(32) not null default '',"
+                + "ctime timestamp not null default current_timestamp,"
+                + "muid bigint not null default 0,"
+                + "mu_name varchar(32) not null default '',"
+                + "mtime timestamp not null default current_timestamp,"
+                + "meta_data clob,"
+                + "status int not null default 0,"
+                + "ak_code varchar(128) not null default '',"
+                + "broadcast_status bigint not null default 0,"
+                + "dom_tree_file_id varchar(256) not null default '',"
+                + "pdf_file_id varchar(256) not null default '',"
+                + "description varchar(256) not null default '',"
+                + "cities varchar(512) not null default '',"
+                + "tags varchar(512) not null default '',"
+                + "unique (file_id, space_code))");
     }
 
     @AfterClass
@@ -93,6 +139,33 @@ public class FileRepoMoveTest {
     }
 
     @Test
+    public void movedSubtreeIsVisibleThroughHierarchyQueries() {
+        fileRepo.moveFileClosures(SOURCE, TARGET);
+
+        List<String> pathIds = fileRepo.getPathFiles(LEAF).stream()
+                .map(FileDB::getFileId)
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList(NEW_ROOT, TARGET, SOURCE, CHILD, LEAF), pathIds);
+
+        Map<String, List<String>> ancestorIds = fileRepo.getFileAncestorIds("sp-0", Collections.singletonList(LEAF));
+        assertEquals(Arrays.asList(NEW_ROOT, TARGET, SOURCE, CHILD), ancestorIds.get(LEAF));
+
+        List<String> targetChildren = fileRepo.findFiles("sp-0", TARGET).stream()
+                .map(FileDB::getFileId)
+                .collect(Collectors.toList());
+        assertEquals(Collections.singletonList(SOURCE), targetChildren);
+
+        Page<FileDB> sourcePage = fileRepo.pageFiles(PageFileOps.builder()
+                .ancestorId(SOURCE)
+                .page(1)
+                .pageSize(10)
+                .order("asc")
+                .build());
+        assertEquals(1, sourcePage.getTotal());
+        assertEquals(CHILD, sourcePage.getData().get(0).getFileId());
+    }
+
+    @Test
     public void moveLeafUsesSameSubtreeAlgorithm() {
         fileRepo.moveFileClosures(LEAF, TARGET);
 
@@ -102,21 +175,6 @@ public class FileRepoMoveTest {
         assertClosure(TARGET, LEAF, 1L, -1L);
         assertClosure(NEW_ROOT, LEAF, 2L, -1L);
         assertClosure(LEAF, LEAF, 0L, 3L);
-    }
-
-    @Test
-    public void failedBatchCanRollBackAllClosureChanges() throws Exception {
-        insertClosure(NEW_ROOT, CHILD, 99L, -1L);
-        Map<String, String> before = snapshot();
-
-        connection.setAutoCommit(false);
-        try {
-            assertThrows(RuntimeException.class, () -> fileRepo.moveFileClosures(SOURCE, TARGET));
-            connection.rollback();
-            assertEquals(before, snapshot());
-        } finally {
-            connection.setAutoCommit(true);
-        }
     }
 
     @Test
@@ -151,10 +209,24 @@ public class FileRepoMoveTest {
         insertClosure(NEW_ROOT, TARGET, 1L, -1L);
     }
 
+    private void insertFiles() {
+        insertFile(OLD_ROOT, "old-root", true);
+        insertFile(SOURCE, "source", true);
+        insertFile(CHILD, "child", true);
+        insertFile(LEAF, "leaf.txt", false);
+        insertFile(NEW_ROOT, "new-root", true);
+        insertFile(TARGET, "target", true);
+    }
+
+    private void insertFile(String fileId, String filename, boolean directory) {
+        dsl.execute("insert into file_0 (file_id, filename, is_dir, space_code, meta_data) values (?, ?, ?, ?, ?)",
+                fileId, filename, directory ? 1 : 0, "sp-0", "{}");
+    }
+
     private void insertClosure(String ancestorId, String descendantId, long depth, long rootDepth) {
         dsl.execute("insert into file_closure_0 "
                         + "(ancestor_id, descendant_id, space_code, depth, root_depth) values (?, ?, ?, ?, ?)",
-                ancestorId, descendantId, "sp-a", depth, rootDepth);
+                ancestorId, descendantId, "sp-0", depth, rootDepth);
     }
 
     private boolean hasClosure(String ancestorId, String descendantId) {

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoTestFixture.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoTestFixture.java
@@ -1,0 +1,19 @@
+package com.ke.bella.files.db.repo;
+
+import static com.ke.bella.files.db.Tables.FILE;
+import static com.ke.bella.files.db.Tables.FILE_CLOSURE;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+
+public final class FileRepoTestFixture {
+    private FileRepoTestFixture() {
+    }
+
+    public static void recreateUserFileTables(DSLContext dsl, String shardKey) {
+        DSLContext shardDsl = DSL.using(dsl.configuration().derive(DSLContextHolder.newSettings(shardKey)));
+        shardDsl.dropTableIfExists(FILE_CLOSURE).execute();
+        shardDsl.dropTableIfExists(FILE).execute();
+        shardDsl.ddl(FILE, FILE_CLOSURE).executeBatch();
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
@@ -41,6 +41,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import com.ke.bella.files.FileShardingCountUpdator;
 import com.ke.bella.files.configuration.BucketConfig;
 import com.ke.bella.files.db.repo.FileRepo;
+import com.ke.bella.files.db.repo.FileRepoTestFixture;
 import com.ke.bella.files.protocol.FileOps;
 import com.ke.bella.files.service.broadcast.BroadcastService;
 import com.ke.bella.files.service.storage.StorageService;
@@ -69,10 +70,7 @@ public class FileServiceMoveTransactionTest {
 
     @Before
     public void setup() {
-        dsl.execute("drop table if exists file_1");
-        dsl.execute("drop table if exists file_closure_1");
-        createFileClosureTable();
-        createFileTable();
+        FileRepoTestFixture.recreateUserFileTables(dsl, "1");
         insertTree();
         insertFile();
         setOperator();
@@ -146,56 +144,6 @@ public class FileServiceMoveTransactionTest {
 
     private static void setOperator() {
         BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
-    }
-
-    private void createFileClosureTable() {
-        dsl.execute("create table file_closure_1 ("
-                + "id bigint auto_increment primary key,"
-                + "ancestor_id varchar(255) not null,"
-                + "descendant_id varchar(255) not null,"
-                + "space_code varchar(128) not null default '',"
-                + "depth bigint not null default 0,"
-                + "root_depth bigint not null default -1,"
-                + "cuid bigint not null default 0,"
-                + "cu_name varchar(32) not null default '',"
-                + "ctime timestamp not null default current_timestamp,"
-                + "muid bigint not null default 0,"
-                + "mu_name varchar(32) not null default '',"
-                + "mtime timestamp not null default current_timestamp,"
-                + "unique (ancestor_id, descendant_id))");
-    }
-
-    private void createFileTable() {
-        dsl.execute("create table file_1 ("
-                + "id bigint auto_increment primary key,"
-                + "file_id varchar(256) not null,"
-                + "version bigint not null default 0,"
-                + "filename varchar(512) not null default '',"
-                + "is_dir int not null default 0,"
-                + "extension varchar(512) not null default '',"
-                + "mime_type varchar(512) not null default '',"
-                + "type varchar(512) not null default '',"
-                + "bucket varchar(256) not null default '',"
-                + "path varchar(512) not null default '',"
-                + "bytes bigint not null default 0,"
-                + "space_code varchar(128) not null default '',"
-                + "purpose varchar(64) not null default '',"
-                + "cuid bigint not null default 0,"
-                + "cu_name varchar(32) not null default '',"
-                + "ctime timestamp not null default current_timestamp,"
-                + "muid bigint not null default 0,"
-                + "mu_name varchar(32) not null default '',"
-                + "mtime timestamp not null default current_timestamp,"
-                + "meta_data clob,"
-                + "status int not null default 0,"
-                + "ak_code varchar(128) not null default '',"
-                + "broadcast_status bigint not null default 0,"
-                + "dom_tree_file_id varchar(256) not null default '',"
-                + "pdf_file_id varchar(256) not null default '',"
-                + "description varchar(256) not null default '',"
-                + "cities varchar(512) not null default '',"
-                + "tags varchar(512) not null default '',"
-                + "unique (file_id, space_code))");
     }
 
     private void insertTree() {

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
@@ -1,6 +1,7 @@
 package com.ke.bella.files.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -8,6 +9,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
@@ -30,6 +36,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.ke.bella.files.FileShardingCountUpdator;
 import com.ke.bella.files.configuration.BucketConfig;
@@ -47,6 +54,7 @@ public class FileServiceMoveTransactionTest {
     private static final String SOURCE = "file-source-1-d";
     private static final String CHILD = "file-child-1-d";
     private static final String TARGET = "file-target-1-d";
+    private static final String CREATED_FILE = "file-created-1-d";
 
     @javax.annotation.Resource
     private DSLContext dsl;
@@ -54,6 +62,10 @@ public class FileServiceMoveTransactionTest {
     private FileService fileService;
     @javax.annotation.Resource
     private BroadcastService broadcastService;
+    @javax.annotation.Resource
+    private FileRepo fileRepo;
+    @javax.annotation.Resource
+    private PlatformTransactionManager transactionManager;
 
     @Before
     public void setup() {
@@ -63,7 +75,7 @@ public class FileServiceMoveTransactionTest {
         createFileTable();
         insertTree();
         insertFile();
-        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+        setOperator();
     }
 
     @Test
@@ -77,6 +89,63 @@ public class FileServiceMoveTransactionTest {
         assertEquals(closuresBefore, snapshotClosures());
         assertEquals(fileBefore, snapshotFile());
         verifyNoInteractions(broadcastService);
+    }
+
+    @Test
+    public void creatingInMovingSubtreeWaitsForNewAncestorChain() throws Exception {
+        CountDownLatch moveCompleted = new CountDownLatch(1);
+        CountDownLatch allowMoveCommit = new CountDownLatch(1);
+        CountDownLatch createStarted = new CountDownLatch(1);
+        CountDownLatch createCompleted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+        try {
+            Future<?> move = executor.submit(() -> transactionTemplate.executeWithoutResult(status -> {
+                setOperator();
+                fileRepo.moveFileClosures(SOURCE, TARGET);
+                moveCompleted.countDown();
+                await(allowMoveCommit);
+            }));
+            assertTrue(moveCompleted.await(5, TimeUnit.SECONDS));
+
+            Future<?> create = executor.submit(() -> {
+                setOperator();
+                createStarted.countDown();
+                fileRepo.addFileClosures(CREATED_FILE, CHILD);
+                createCompleted.countDown();
+            });
+            assertTrue(createStarted.await(5, TimeUnit.SECONDS));
+            assertFalse(createCompleted.await(200, TimeUnit.MILLISECONDS));
+
+            allowMoveCommit.countDown();
+            move.get(5, TimeUnit.SECONDS);
+            create.get(5, TimeUnit.SECONDS);
+
+            assertFalse(hasClosure(OLD_ROOT, CREATED_FILE));
+            assertClosure(TARGET, CREATED_FILE, 3L);
+            assertClosure(SOURCE, CREATED_FILE, 2L);
+            assertClosure(CHILD, CREATED_FILE, 1L);
+            assertClosure(CREATED_FILE, CREATED_FILE, 0L);
+        } finally {
+            allowMoveCommit.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if(!latch.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("timed out waiting for concurrent transaction");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void setOperator() {
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
     }
 
     private void createFileClosureTable() {
@@ -165,6 +234,18 @@ public class FileServiceMoveTransactionTest {
             snapshot.put(key, record.get(2, Long.class) + ":" + record.get(3, Long.class));
         }
         return snapshot;
+    }
+
+    private boolean hasClosure(String ancestorId, String descendantId) {
+        Record record = dsl.fetchOne("select count(*) from file_closure_1 where ancestor_id = ? and descendant_id = ?",
+                ancestorId, descendantId);
+        return record.get(0, Number.class).intValue() > 0;
+    }
+
+    private void assertClosure(String ancestorId, String descendantId, long depth) {
+        Record record = dsl.fetchOne("select depth from file_closure_1 where ancestor_id = ? and descendant_id = ?",
+                ancestorId, descendantId);
+        assertEquals(depth, record.get(0, Long.class).longValue());
     }
 
     @Configuration

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
@@ -1,0 +1,243 @@
+package com.ke.bella.files.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DataSourceConnectionProvider;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import com.ke.bella.files.FileShardingCountUpdator;
+import com.ke.bella.files.configuration.BucketConfig;
+import com.ke.bella.files.db.repo.FileRepo;
+import com.ke.bella.files.protocol.FileOps;
+import com.ke.bella.files.service.broadcast.BroadcastService;
+import com.ke.bella.files.service.storage.StorageService;
+import com.ke.bella.openapi.BellaContext;
+import com.ke.bella.openapi.Operator;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = FileServiceMoveTransactionTest.TestConfig.class)
+public class FileServiceMoveTransactionTest {
+    private static final String OLD_ROOT = "file-old-1-d";
+    private static final String SOURCE = "file-source-1-d";
+    private static final String CHILD = "file-child-1-d";
+    private static final String TARGET = "file-target-1-d";
+
+    @javax.annotation.Resource
+    private DSLContext dsl;
+    @javax.annotation.Resource
+    private FileService fileService;
+    @javax.annotation.Resource
+    private BroadcastService broadcastService;
+
+    @Before
+    public void setup() {
+        dsl.execute("drop table if exists file_1");
+        dsl.execute("drop table if exists file_closure_1");
+        createFileClosureTable();
+        createFileTable();
+        insertTree();
+        insertFile();
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+    }
+
+    @Test
+    public void updateFailureRollsBackClosuresAndSkipsLocationBroadcast() {
+        Map<String, String> closuresBefore = snapshotClosures();
+        String fileBefore = snapshotFile();
+
+        RuntimeException error = assertThrows(RuntimeException.class, () -> fileService.moveFile(SOURCE, TARGET));
+
+        assertTrue(error.getMessage().contains("simulated location update failure"));
+        assertEquals(closuresBefore, snapshotClosures());
+        assertEquals(fileBefore, snapshotFile());
+        verifyNoInteractions(broadcastService);
+    }
+
+    private void createFileClosureTable() {
+        dsl.execute("create table file_closure_1 ("
+                + "id bigint auto_increment primary key,"
+                + "ancestor_id varchar(255) not null,"
+                + "descendant_id varchar(255) not null,"
+                + "space_code varchar(128) not null default '',"
+                + "depth bigint not null default 0,"
+                + "root_depth bigint not null default -1,"
+                + "cuid bigint not null default 0,"
+                + "cu_name varchar(32) not null default '',"
+                + "ctime timestamp not null default current_timestamp,"
+                + "muid bigint not null default 0,"
+                + "mu_name varchar(32) not null default '',"
+                + "mtime timestamp not null default current_timestamp,"
+                + "unique (ancestor_id, descendant_id))");
+    }
+
+    private void createFileTable() {
+        dsl.execute("create table file_1 ("
+                + "id bigint auto_increment primary key,"
+                + "file_id varchar(256) not null,"
+                + "version bigint not null default 0,"
+                + "filename varchar(512) not null default '',"
+                + "is_dir int not null default 0,"
+                + "extension varchar(512) not null default '',"
+                + "mime_type varchar(512) not null default '',"
+                + "type varchar(512) not null default '',"
+                + "bucket varchar(256) not null default '',"
+                + "path varchar(512) not null default '',"
+                + "bytes bigint not null default 0,"
+                + "space_code varchar(128) not null default '',"
+                + "purpose varchar(64) not null default '',"
+                + "cuid bigint not null default 0,"
+                + "cu_name varchar(32) not null default '',"
+                + "ctime timestamp not null default current_timestamp,"
+                + "muid bigint not null default 0,"
+                + "mu_name varchar(32) not null default '',"
+                + "mtime timestamp not null default current_timestamp,"
+                + "meta_data clob,"
+                + "status int not null default 0,"
+                + "ak_code varchar(128) not null default '',"
+                + "broadcast_status bigint not null default 0,"
+                + "dom_tree_file_id varchar(256) not null default '',"
+                + "pdf_file_id varchar(256) not null default '',"
+                + "description varchar(256) not null default '',"
+                + "cities varchar(512) not null default '',"
+                + "tags varchar(512) not null default '',"
+                + "unique (file_id, space_code))");
+    }
+
+    private void insertTree() {
+        insertClosure(OLD_ROOT, OLD_ROOT, 0L, 1L);
+        insertClosure(SOURCE, SOURCE, 0L, 2L);
+        insertClosure(OLD_ROOT, SOURCE, 1L, -1L);
+        insertClosure(CHILD, CHILD, 0L, 3L);
+        insertClosure(SOURCE, CHILD, 1L, -1L);
+        insertClosure(OLD_ROOT, CHILD, 2L, -1L);
+        insertClosure(TARGET, TARGET, 0L, 1L);
+    }
+
+    private void insertFile() {
+        dsl.execute("insert into file_1 (file_id, filename, is_dir, space_code, meta_data, mtime) "
+                        + "values (?, ?, ?, ?, ?, timestamp '2026-01-01 00:00:00')",
+                SOURCE, "source", 1, "sp-a", "{}");
+    }
+
+    private void insertClosure(String ancestorId, String descendantId, long depth, long rootDepth) {
+        dsl.execute("insert into file_closure_1 "
+                        + "(ancestor_id, descendant_id, space_code, depth, root_depth) values (?, ?, ?, ?, ?)",
+                ancestorId, descendantId, "sp-a", depth, rootDepth);
+    }
+
+    private String snapshotFile() {
+        Record record = dsl.fetchOne("select muid, mu_name, mtime from file_1 where file_id = ?", SOURCE);
+        return record.get(0, Long.class) + ":" + record.get(1, String.class) + ":" + record.get(2).toString();
+    }
+
+    private Map<String, String> snapshotClosures() {
+        Result<Record> records = dsl.fetch("select ancestor_id, descendant_id, depth, root_depth "
+                + "from file_closure_1 order by ancestor_id, descendant_id");
+        Map<String, String> snapshot = new LinkedHashMap<>();
+        for (Record record : records) {
+            String key = record.get(0, String.class) + "->" + record.get(1, String.class);
+            snapshot.put(key, record.get(2, Long.class) + ":" + record.get(3, Long.class));
+        }
+        return snapshot;
+    }
+
+    @Configuration
+    @EnableTransactionManagement(proxyTargetClass = true)
+    public static class TestConfig {
+        @Bean
+        public DataSource dataSource() {
+            JdbcDataSource dataSource = new JdbcDataSource();
+            dataSource.setURL("jdbc:h2:mem:fileServiceMove;MODE=MySQL;DB_CLOSE_DELAY=-1");
+            dataSource.setUser("sa");
+            return dataSource;
+        }
+
+        @Bean
+        public PlatformTransactionManager transactionManager(DataSource dataSource) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+
+        @Bean
+        public DSLContext dslContext(DataSource dataSource) {
+            DefaultConfiguration configuration = new DefaultConfiguration();
+            configuration.setSQLDialect(SQLDialect.MYSQL);
+            configuration.setConnectionProvider(new DataSourceConnectionProvider(
+                    new TransactionAwareDataSourceProxy(dataSource)));
+            return new DefaultDSLContext(configuration);
+        }
+
+        @Bean
+        public FileRepo fileRepo(DSLContext dslContext) {
+            return new FailingFileRepo(dslContext);
+        }
+
+        @Bean
+        public BroadcastService broadcastService() {
+            return mock(BroadcastService.class);
+        }
+
+        @Bean
+        public StorageService storageService() {
+            return mock(StorageService.class);
+        }
+
+        @Bean
+        public BucketConfig bucketConfig() {
+            return mock(BucketConfig.class);
+        }
+
+        @Bean
+        public FileShardingCountUpdator fileShardingCountUpdator() {
+            return mock(FileShardingCountUpdator.class);
+        }
+
+        @Bean
+        public FileService fileService() {
+            return new TestFileService();
+        }
+    }
+
+    private static class FailingFileRepo extends FileRepo {
+        FailingFileRepo(DSLContext dslContext) {
+            super(dslContext);
+        }
+
+        @Override
+        public void updateFile(FileOps op, boolean increaseVersion) {
+            super.updateFile(op, increaseVersion);
+            throw new IllegalStateException("simulated location update failure");
+        }
+    }
+
+    private static class TestFileService extends FileService {
+        @Override
+        public void init() {
+        }
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceMoveTransactionTest.java
@@ -254,7 +254,7 @@ public class FileServiceMoveTransactionTest {
         @Bean
         public DataSource dataSource() {
             JdbcDataSource dataSource = new JdbcDataSource();
-            dataSource.setURL("jdbc:h2:mem:fileServiceMove;MODE=MySQL;DB_CLOSE_DELAY=-1");
+            dataSource.setURL("jdbc:h2:mem:fileServiceMove;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1");
             dataSource.setUser("sa");
             return dataSource;
         }
@@ -267,7 +267,7 @@ public class FileServiceMoveTransactionTest {
         @Bean
         public DSLContext dslContext(DataSource dataSource) {
             DefaultConfiguration configuration = new DefaultConfiguration();
-            configuration.setSQLDialect(SQLDialect.MYSQL);
+            configuration.setSQLDialect(SQLDialect.H2);
             configuration.setConnectionProvider(new DataSourceConnectionProvider(
                     new TransactionAwareDataSourceProxy(dataSource)));
             return new DefaultDSLContext(configuration);

--- a/api/src/test/java/com/ke/bella/files/service/lock/RedisFileUniquenessLockTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/lock/RedisFileUniquenessLockTest.java
@@ -1,0 +1,67 @@
+package com.ke.bella.files.service.lock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.redisson.api.RLock;
+import org.redisson.api.RReadWriteLock;
+import org.redisson.api.RedissonClient;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RedisFileUniquenessLockTest {
+    private static final long TIMEOUT_MS = 30000L;
+
+    @Mock
+    private RedissonClient redissonClient;
+    @Mock
+    private RReadWriteLock readWriteLock;
+    @Mock
+    private RLock readLock;
+    @Mock
+    private RLock writeLock;
+    @InjectMocks
+    private RedisFileUniquenessLock fileLock;
+
+    @Before
+    public void setup() {
+        when(redissonClient.getReadWriteLock("file-api:file:move:sp-a")).thenReturn(readWriteLock);
+        when(readWriteLock.readLock()).thenReturn(readLock);
+        when(readWriteLock.writeLock()).thenReturn(writeLock);
+    }
+
+    @Test
+    public void directoryMoveUsesSpaceWriteLock() throws Exception {
+        when(writeLock.tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS)).thenReturn(true);
+        when(writeLock.isHeldByCurrentThread()).thenReturn(true);
+
+        String result = fileLock.executeWithMoveLock("sp-a", true, TIMEOUT_MS, () -> "moved");
+
+        assertEquals("moved", result);
+        verify(writeLock).tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        verify(writeLock).unlock();
+        verify(readLock, never()).tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void fileMoveUsesSpaceReadLock() throws Exception {
+        when(readLock.tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS)).thenReturn(true);
+        when(readLock.isHeldByCurrentThread()).thenReturn(true);
+
+        String result = fileLock.executeWithMoveLock("sp-a", false, TIMEOUT_MS, () -> "moved");
+
+        assertEquals("moved", result);
+        verify(readLock).tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        verify(readLock).unlock();
+        verify(writeLock, never()).tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
<!-- issue-flow:source-issue=60 -->
<!-- issue-flow:source source_task_id=task-cmsijphp9000j3f1g3job77bf source_runtime=agentrix -->
## Source issue

Closes #60

## Summary

- Allow `POST /v1/files/move` to move directories as well as files, while rechecking the current parent and duplicate name after acquiring the target uniqueness lock.
- Replace leaf-only closure deletion/recreation with a transactional subtree migration that locks closure snapshots, rejects self/descendant cycles, preserves internal subtree relationships, rewires external ancestors, and updates every moved node's `root_depth`.
- Use a single `INSERT ... SELECT` cross join and one MySQL `UPDATE JOIN` for set-based subtree closure writes; exact affected-row assertions remain for insertion and `root_depth` updates.
- Delete old external closure rows as an idempotent set operation without requiring the affected count to equal `external ancestors × subtree nodes`, so missing legacy/inconsistent external rows do not incorrectly block an otherwise repairable move.
- Serialize file creation with concurrent directory moves by locking and refreshing the parent ancestor chain before closure insertion.
- Add a Redis space-level move read/write lock: directory moves take the exclusive write lock, normal file moves take the shared read lock, and both acquire it before the existing target filename lock.
- Expand hierarchy-query coverage for paths, ancestors, direct children, pagination, transaction rollback, concurrent creation, move lock selection/release, and moves with a missing old external closure row.
- Replace duplicated H2 `file_{shard}` and `file_closure_{shard}` DDL in the new database tests with a shared fixture generated from the repository's jOOQ schema metadata and shard render mapping.
- Deviation from the approved plan: the plan required an exact delete-count assertion. Review determined that this assumes a complete Cartesian external-closure set and rejects repairable pre-existing data gaps, so deletion is now best-effort over the selected set while subsequent insertion/update consistency checks remain strict.

## Validation

- `cd api && mvn -Dtest=FileRepoMoveTest,FileServiceMoveTransactionTest test` — passed, 7 tests.
- `cd api && mvn test` — passed, 94 tests.
- `cd api && mvn checkstyle:check` — blocked by the repository baseline: the unconfigured goal uses default `sun_checks.xml` and reports 2,860 existing project-wide violations, including untouched files.
- `git diff --check` — passed.
