### PR TITLE
Build #65: 支持移动文件到空间根目录

### DIFF
--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1223,7 +1223,7 @@ public class FileController {
         if(file == null) {
             throw new FileNotFoundException(fileId);
         }
-        Assert.isTrue(StringUtils.equals(spaceCode, file.getSpaceCode()), "space mismatch for file_id and ancestor_id");
+        Assert.isTrue(StringUtils.equals(spaceCode, file.getSpaceCode()), "space mismatch between context and file_id");
 
         try {
             boolean directory = file.getIsDir() == 1;

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1204,37 +1204,37 @@ public class FileController {
         Assert.notNull(op, "invalid request body");
 
         String fileId = op.getFileId();
-        String targetAncestorId = op.getAncestorId();
+        String targetAncestorId = StringUtils.trimToNull(op.getAncestorId());
+        String spaceCode = BellaContextHelper.getOperateSpaceCode();
 
         Assert.hasText(fileId, "file_id is required and cannot be empty");
-        Assert.hasText(targetAncestorId, "ancestor_id is required and cannot be empty");
 
-        // validate and get ancestor (target directory)
-        FileDB ancestor = fileService.getFile0(targetAncestorId);
-        if(ancestor == null) {
-            throw new FileNotFoundException(targetAncestorId);
+        if(targetAncestorId != null) {
+            FileDB ancestor = fileService.getFile0(targetAncestorId);
+            if(ancestor == null) {
+                throw new FileNotFoundException(targetAncestorId);
+            }
+            Assert.isTrue(ancestor.getIsDir() == 1, "ancestor_id must refer to a directory");
+            Assert.isTrue(StringUtils.equals(spaceCode, ancestor.getSpaceCode()),
+                    "space_code mismatch between context and ancestor_id");
         }
-        Assert.isTrue(ancestor.getIsDir() == 1, "ancestor_id must refer to a directory");
-        Assert.isTrue(StringUtils.equals(BellaContextHelper.getOperateSpaceCode(), ancestor.getSpaceCode()),
-                "space_code mismatch between context and ancestor_id");
 
-        // validate file to move
         FileDB file = fileService.getFile0(fileId);
         if(file == null) {
             throw new FileNotFoundException(fileId);
         }
-        Assert.isTrue(StringUtils.equals(ancestor.getSpaceCode(), file.getSpaceCode()), "space mismatch for file_id and ancestor_id");
+        Assert.isTrue(StringUtils.equals(spaceCode, file.getSpaceCode()), "space mismatch for file_id and ancestor_id");
 
         try {
             boolean directory = file.getIsDir() == 1;
-            return fl.executeWithMoveLock(ancestor.getSpaceCode(), directory, FILE_LOCK_TIMEOUT_MS,
-                    () -> fl.executeWithLock(ancestor.getSpaceCode(), targetAncestorId, file.getFilename(), FILE_LOCK_TIMEOUT_MS,
+            return fl.executeWithMoveLock(spaceCode, directory, FILE_LOCK_TIMEOUT_MS,
+                    () -> fl.executeWithLock(spaceCode, targetAncestorId, file.getFilename(), FILE_LOCK_TIMEOUT_MS,
                             () -> {
                                 String currentAncestorId = fileService.getDirectAncestorId(fileId);
                                 Assert.isTrue(!StringUtils.equals(currentAncestorId, targetAncestorId),
                                         "file already in target directory");
 
-                                boolean exists = fileService.exists(ancestor.getSpaceCode(), targetAncestorId, file.getFilename());
+                                boolean exists = fileService.exists(spaceCode, targetAncestorId, file.getFilename());
                                 Assert.isTrue(!exists, "filename already exists");
 
                                 return fileService.moveFile(fileId, targetAncestorId);

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -530,21 +530,26 @@ public class FileRepo implements BaseRepo {
         Assert.isTrue(!CollectionUtils.isEmpty(sourceAncestorClosures),
                 "descendant_id not found in file_closure, descendant_id: " + fileId);
 
-        List<FileClosureRecord> targetAncestorClosures = dsl.selectFrom(FILE_CLOSURE)
-                .where(FILE_CLOSURE.DESCENDANT_ID.eq(targetAncestorId))
-                .orderBy(FILE_CLOSURE.DEPTH.asc())
-                .forUpdate()
-                .fetchInto(FileClosureRecord.class);
-        Assert.isTrue(!CollectionUtils.isEmpty(targetAncestorClosures),
-                "descendant_id not found in file_closure, descendant_id: " + targetAncestorId);
+        List<FileClosureRecord> targetAncestorClosures = Collections.emptyList();
+        long targetRootDepth = 0L;
+        if(StringUtils.isNotEmpty(targetAncestorId)) {
+            targetAncestorClosures = dsl.selectFrom(FILE_CLOSURE)
+                    .where(FILE_CLOSURE.DESCENDANT_ID.eq(targetAncestorId))
+                    .orderBy(FILE_CLOSURE.DEPTH.asc())
+                    .forUpdate()
+                    .fetchInto(FileClosureRecord.class);
+            Assert.isTrue(!CollectionUtils.isEmpty(targetAncestorClosures),
+                    "descendant_id not found in file_closure, descendant_id: " + targetAncestorId);
 
-        FileClosureRecord targetSelfClosure = targetAncestorClosures.stream()
-                .filter(closure -> closure.getDepth() == 0L)
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException(
-                        "self closure not found, descendant_id: " + targetAncestorId));
-        Assert.isTrue(targetSelfClosure.getRootDepth() > 0,
-                "invalid root_depth for target ancestor, descendant_id: " + targetAncestorId);
+            FileClosureRecord targetSelfClosure = targetAncestorClosures.stream()
+                    .filter(closure -> closure.getDepth() == 0L)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "self closure not found, descendant_id: " + targetAncestorId));
+            Assert.isTrue(targetSelfClosure.getRootDepth() > 0,
+                    "invalid root_depth for target ancestor, descendant_id: " + targetAncestorId);
+            targetRootDepth = targetSelfClosure.getRootDepth();
+        }
 
         List<String> subtreeIds = subtreeClosures.stream()
                 .map(FileClosureRecord::getDescendantId)
@@ -555,7 +560,7 @@ public class FileRepo implements BaseRepo {
                 .collect(Collectors.toList());
 
         return new ClosureMoveSnapshot(subtreeIds, externalAncestorIds, targetAncestorId,
-                targetAncestorClosures.size(), targetSelfClosure.getRootDepth());
+                targetAncestorClosures.size(), targetRootDepth);
     }
 
     private void deleteExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot) {
@@ -568,6 +573,10 @@ public class FileRepo implements BaseRepo {
     }
 
     private void insertExternalClosures(DSLContext dsl, ClosureMoveSnapshot snapshot, String fileId) {
+        if(StringUtils.isEmpty(snapshot.targetAncestorId)) {
+            return;
+        }
+
         Table<FileClosureRecord> target = FILE_CLOSURE.as("target_closure");
         Table<FileClosureRecord> subtree = FILE_CLOSURE.as("subtree_closure");
         Field<String> targetAncestorId = target.field(FILE_CLOSURE.ANCESTOR_ID);

--- a/api/src/main/java/com/ke/bella/files/service/lock/RedisFileUniquenessLock.java
+++ b/api/src/main/java/com/ke/bella/files/service/lock/RedisFileUniquenessLock.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.StringUtils;
 import org.redisson.api.RLock;
 import org.redisson.api.RReadWriteLock;
 import org.redisson.api.RedissonClient;
@@ -130,8 +131,9 @@ public class RedisFileUniquenessLock implements FileUniquenessLock {
 
     private String buildLockKey(String spaceCode, String ancestorId, String filename) {
         try {
+            String normalizedAncestorId = StringUtils.trimToNull(ancestorId);
             String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8.name());
-            return LOCK_PREFIX + spaceCode + ":" + ancestorId + ":" + encodedFilename;
+            return LOCK_PREFIX + spaceCode + ":" + normalizedAncestorId + ":" + encodedFilename;
         } catch (Exception e) {
             LOGGER.error("Error encoding lock key parameters", e);
             throw new IllegalStateException("Failed to build lock key", e);

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
@@ -249,7 +249,7 @@ public class FileControllerMoveTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"file_id\":\"" + fileId + "\"}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.message").value("space mismatch for file_id and ancestor_id"));
+                .andExpect(jsonPath("$.error.message").value("space mismatch between context and file_id"));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
     }
@@ -323,7 +323,7 @@ public class FileControllerMoveTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.message").value("space mismatch for file_id and ancestor_id"));
+                .andExpect(jsonPath("$.error.message").value("space mismatch between context and file_id"));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
     }

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMoveTest.java
@@ -142,6 +142,119 @@ public class FileControllerMoveTest {
     }
 
     @Test
+    public void moveToRootWhenAncestorIdMissing() throws Exception {
+        String spaceCode = "sp-a";
+        String fileId = "f-1";
+        FileDB source = buildFile(fileId, "name.txt", false, spaceCode);
+        OpenAIFile moved = OpenAIFile.builder()
+                .id(fileId)
+                .filename("name.txt")
+                .spaceCode(spaceCode)
+                .build();
+
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq((String) null), eq("name.txt"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+        when(fileService.getDirectAncestorId(fileId)).thenReturn("parent-1");
+        when(fileService.moveFile(fileId, null)).thenReturn(moved);
+
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"file_id\":\"" + fileId + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(fileId));
+
+        verify(fileService).exists(spaceCode, null, "name.txt");
+        verify(fileService).moveFile(fileId, null);
+    }
+
+    @Test
+    public void moveToRootWhenAncestorIdEmpty() throws Exception {
+        String spaceCode = "sp-a";
+        String fileId = "dir-1";
+        FileDB source = buildFile(fileId, "source", true, spaceCode);
+
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq((String) null), eq("source"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+        when(fileService.getDirectAncestorId(fileId)).thenReturn("parent-1");
+        when(fileService.moveFile(fileId, null)).thenReturn(OpenAIFile.builder().id(fileId).build());
+
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"file_id\":\"" + fileId + "\",\"ancestor_id\":\"\"}"))
+                .andExpect(status().isOk());
+
+        verify(fileUniquenessLock).executeWithMoveLock(eq(spaceCode), eq(true), anyLong(), any());
+        verify(fileService).moveFile(fileId, null);
+    }
+
+    @Test
+    public void moveToRootRejectsFileAlreadyAtRoot() throws Exception {
+        String spaceCode = "sp-a";
+        String fileId = "f-1";
+        FileDB source = buildFile(fileId, "name.txt", false, spaceCode);
+
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq((String) null), eq("name.txt"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+        when(fileService.getDirectAncestorId(fileId)).thenReturn(null);
+
+        BellaContext.setOperator(Operator.builder().spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"file_id\":\"" + fileId + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("file already in target directory"));
+
+        verify(fileService, never()).moveFile(any(), any());
+    }
+
+    @Test
+    public void moveToRootRejectsDuplicateName() throws Exception {
+        String spaceCode = "sp-a";
+        String fileId = "f-1";
+        FileDB source = buildFile(fileId, "name.txt", false, spaceCode);
+
+        when(fileService.getFile0(fileId)).thenReturn(source);
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq((String) null), eq("name.txt"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+        when(fileService.getDirectAncestorId(fileId)).thenReturn("parent-1");
+        when(fileService.exists(spaceCode, null, "name.txt")).thenReturn(true);
+
+        BellaContext.setOperator(Operator.builder().spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"file_id\":\"" + fileId + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("filename already exists"));
+
+        verify(fileService, never()).moveFile(any(), any());
+    }
+
+    @Test
+    public void moveToRootRejectsSourceFromAnotherSpace() throws Exception {
+        String fileId = "f-1";
+        when(fileService.getFile0(fileId)).thenReturn(buildFile(fileId, "name.txt", false, "sp-b"));
+
+        BellaContext.setOperator(Operator.builder().spaceCode("sp-a").build());
+        mockMvc.perform(post("/v1/files/move")
+                .header("X-BELLA-SPACE-CODE", "sp-a")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"file_id\":\"" + fileId + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("space mismatch for file_id and ancestor_id"));
+
+        verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
+    }
+
+    @Test
     public void moveCurrentDirectoryCheckedInsideLock() throws Exception {
         String ancestorId = "anc-1";
         String spaceCode = "sp-a";
@@ -336,19 +449,6 @@ public class FileControllerMoveTest {
                 .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.message").value("file_id is required and cannot be empty"));
-    }
-
-    @Test
-    public void moveMissingAncestorIdBadRequest() throws Exception {
-        String body = "{\"file_id\":\"f-1\"}";
-
-        BellaContext.setOperator(Operator.builder().spaceCode("sp-a").build());
-        mockMvc.perform(post("/v1/files/move")
-                .header("X-BELLA-SPACE-CODE", "sp-a")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.message").value("ancestor_id is required and cannot be empty"));
     }
 
     @Test

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -138,6 +138,58 @@ public class FileRepoMoveTest {
     }
 
     @Test
+    public void moveDirectoryToRootRemovesExternalAncestorsAndResetsRootDepths() {
+        fileRepo.moveFileClosures(SOURCE, null);
+
+        assertFalse(hasClosure(OLD_ROOT, SOURCE));
+        assertFalse(hasClosure(OLD_ROOT, CHILD));
+        assertFalse(hasClosure(OLD_ROOT, LEAF));
+
+        assertClosure(SOURCE, CHILD, 1L, -1L);
+        assertClosure(SOURCE, LEAF, 2L, -1L);
+        assertClosure(CHILD, LEAF, 1L, -1L);
+        assertClosure(SOURCE, SOURCE, 0L, 1L);
+        assertClosure(CHILD, CHILD, 0L, 2L);
+        assertClosure(LEAF, LEAF, 0L, 3L);
+    }
+
+    @Test
+    public void moveLeafToRootResetsRootDepth() {
+        fileRepo.moveFileClosures(LEAF, "");
+
+        assertFalse(hasClosure(OLD_ROOT, LEAF));
+        assertFalse(hasClosure(SOURCE, LEAF));
+        assertFalse(hasClosure(CHILD, LEAF));
+        assertClosure(LEAF, LEAF, 0L, 1L);
+    }
+
+    @Test
+    public void movedSubtreeToRootIsVisibleThroughHierarchyQueries() {
+        fileRepo.moveFileClosures(SOURCE, null);
+
+        List<String> pathIds = fileRepo.getPathFiles(LEAF).stream()
+                .map(FileDB::getFileId)
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList(SOURCE, CHILD, LEAF), pathIds);
+
+        List<String> rootFiles = fileRepo.findFiles("sp-0", null).stream()
+                .map(FileDB::getFileId)
+                .collect(Collectors.toList());
+        assertTrue(rootFiles.contains(SOURCE));
+        assertTrue(rootFiles.contains(OLD_ROOT));
+        assertTrue(rootFiles.contains(NEW_ROOT));
+
+        Page<FileDB> sourcePage = fileRepo.pageFiles(PageFileOps.builder()
+                .ancestorId(SOURCE)
+                .page(1)
+                .pageSize(10)
+                .order("asc")
+                .build());
+        assertEquals(1, sourcePage.getTotal());
+        assertEquals(CHILD, sourcePage.getData().get(0).getFileId());
+    }
+
+    @Test
     public void movingToSelfOrDescendantDoesNotChangeClosures() {
         Map<String, String> before = snapshot();
 

--- a/api/src/test/java/com/ke/bella/files/service/lock/RedisFileUniquenessLockTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/lock/RedisFileUniquenessLockTest.java
@@ -2,6 +2,7 @@ package com.ke.bella.files.service.lock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,8 @@ public class RedisFileUniquenessLockTest {
     private RLock readLock;
     @Mock
     private RLock writeLock;
+    @Mock
+    private RLock uniquenessLock;
     @InjectMocks
     private RedisFileUniquenessLock fileLock;
 
@@ -63,5 +66,19 @@ public class RedisFileUniquenessLockTest {
         verify(readLock).tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         verify(readLock).unlock();
         verify(writeLock, never()).tryLock(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void rootAncestorVariantsUseSameUniquenessLockKey() throws Exception {
+        String key = "file-api:file:uniqueness:sp-a:null:name.txt";
+        when(redissonClient.getLock(key)).thenReturn(uniquenessLock);
+        when(uniquenessLock.tryLock(0, TIMEOUT_MS, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+        fileLock.tryLock("sp-a", null, "name.txt", TIMEOUT_MS);
+        fileLock.tryLock("sp-a", "", "name.txt", TIMEOUT_MS);
+        fileLock.tryLock("sp-a", "  ", "name.txt", TIMEOUT_MS);
+
+        verify(redissonClient, times(3)).getLock(key);
+        verify(uniquenessLock, times(3)).tryLock(0, TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
<!-- issue-flow:source-issue=65 -->
<!-- issue-flow:source source_task_id=task-cmsitopv002bf3f1g9m516lm2 source_runtime=agentrix -->
## Source issue

- #65

## Summary

- Allow `POST /v1/files/move` to treat an omitted, empty, or whitespace-only `ancestor_id` as the current space root.
- Keep source-space validation, current-directory rejection, duplicate-name checks, and move/uniqueness locking for root moves.
- Extend closure-table moves so root targets remove external ancestor rows without inserting a synthetic ancestor, then reset subtree self-closure `root_depth` values from 1.
- Normalize root ancestor variants in `RedisFileUniquenessLock` so move, mkdir, and upload operations share the same uniqueness lock key.
- Report source-space violations as a mismatch between the operation context and `file_id`.
- Add controller, repository, and lock-layer regression coverage.

## Validation

- `git diff --check` (passed)
- `mvn -Dtest=FileControllerMoveTest,FileRepoMoveTest,FileServiceMoveTransactionTest,RedisFileUniquenessLockTest test` (not run: the execution environment has no Java, Maven, Docker, or Podman)
