### PR TITLE
Build #71: Support non-file resource nodes

### DIFF
--- a/api/sql/22-update.20260810.sql
+++ b/api/sql/22-update.20260810.sql
@@ -1,0 +1,41 @@
+ALTER TABLE `file`
+    ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file' COMMENT '节点类型：file、directory、resource',
+    ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '' COMMENT '业务资源标识',
+    ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+
+ALTER TABLE `file_0` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_1` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_2` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_3` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_4` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_5` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_6` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_7` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_8` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_9` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_10` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_11` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_12` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_13` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_14` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_15` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_temp` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_system` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+
+UPDATE `file` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_0` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_1` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_2` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_3` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_4` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_5` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_6` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_7` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_8` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_9` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_10` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_11` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_12` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_13` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_14` SET `node_type` = 'directory' WHERE `is_dir` = 1;
+UPDATE `file_15` SET `node_type` = 'directory' WHERE `is_dir` = 1;

--- a/api/sql/22-update.20260810.sql
+++ b/api/sql/22-update.20260810.sql
@@ -21,6 +21,45 @@ ALTER TABLE `file_15` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file'
 ALTER TABLE `file_temp` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
 ALTER TABLE `file_system` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
 
+-- key 为空的基础表已在上方迁移；历史 temp/system 文件仍会按 file_sharding 路由到已滚动分片，因此需要逐表补列。
+DROP PROCEDURE IF EXISTS `migrate_file_resource_shards`;
+DELIMITER //
+CREATE PROCEDURE `migrate_file_resource_shards`()
+BEGIN
+    DECLARE done int DEFAULT 0;
+    DECLARE shard_type varchar(32);
+    DECLARE shard_key varchar(255);
+    DECLARE shard_table varchar(512);
+    DECLARE shard_cursor CURSOR FOR
+        SELECT `type`, `key`
+        FROM `file_sharding`
+        WHERE `type` IN ('temp', 'system') AND `key` <> ''
+        ORDER BY `id`;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;
+
+    OPEN shard_cursor;
+    shard_loop: LOOP
+        FETCH shard_cursor INTO shard_type, shard_key;
+        IF done = 1 THEN
+            LEAVE shard_loop;
+        END IF;
+
+        SET shard_table = CONCAT('file_', shard_type, '_', shard_key);
+        SET @alter_shard_sql = CONCAT(
+                'ALTER TABLE `', REPLACE(shard_table, '`', '``'),
+                '` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT ', CHAR(39), 'file', CHAR(39), ',',
+                ' ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT ', CHAR(39), CHAR(39)
+            );
+        PREPARE alter_shard_stmt FROM @alter_shard_sql;
+        EXECUTE alter_shard_stmt;
+        DEALLOCATE PREPARE alter_shard_stmt;
+    END LOOP;
+    CLOSE shard_cursor;
+END//
+CALL `migrate_file_resource_shards`()//
+DROP PROCEDURE `migrate_file_resource_shards`//
+DELIMITER ;
+
 UPDATE `file` SET `node_type` = 'directory' WHERE `is_dir` = 1;
 UPDATE `file_0` SET `node_type` = 'directory' WHERE `is_dir` = 1;
 UPDATE `file_1` SET `node_type` = 'directory' WHERE `is_dir` = 1;

--- a/api/sql/22-update.20260810.sql
+++ b/api/sql/22-update.20260810.sql
@@ -1,26 +1,25 @@
 ALTER TABLE `file`
     ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file' COMMENT '节点类型：file、directory、resource',
-    ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '' COMMENT '业务资源标识',
-    ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+    ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '' COMMENT '业务资源标识';
 
-ALTER TABLE `file_0` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_1` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_2` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_3` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_4` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_5` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_6` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_7` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_8` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_9` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_10` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_11` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_12` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_13` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_14` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_15` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_temp` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
-ALTER TABLE `file_system` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '', ADD INDEX `idx_resource` (`space_code`, `node_type`, `resource_id`(128), `status`);
+ALTER TABLE `file_0` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_1` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_2` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_3` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_4` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_5` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_6` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_7` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_8` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_9` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_10` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_11` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_12` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_13` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_14` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_15` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_temp` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
+ALTER TABLE `file_system` ADD COLUMN `node_type` varchar(16) NOT NULL DEFAULT 'file', ADD COLUMN `resource_id` varchar(256) NOT NULL DEFAULT '';
 
 UPDATE `file` SET `node_type` = 'directory' WHERE `is_dir` = 1;
 UPDATE `file_0` SET `node_type` = 'directory' WHERE `is_dir` = 1;

--- a/api/src/codegen/java/com/ke/bella/files/db/tables/File.java
+++ b/api/src/codegen/java/com/ke/bella/files/db/tables/File.java
@@ -190,6 +190,16 @@ public class File extends TableImpl<FileRecord> {
      */
     public final TableField<FileRecord, String> TAGS = createField(DSL.name("tags"), SQLDataType.VARCHAR(512).nullable(false).defaultValue(DSL.inline("", SQLDataType.VARCHAR)), this, "标签,示例[\"tag1\",\"tag2\"]");
 
+    /**
+     * The column <code>file.node_type</code>. 节点类型：file、directory、resource
+     */
+    public final TableField<FileRecord, String> NODE_TYPE = createField(DSL.name("node_type"), SQLDataType.VARCHAR(16).nullable(false).defaultValue(DSL.inline("file", SQLDataType.VARCHAR)), this, "节点类型：file、directory、resource");
+
+    /**
+     * The column <code>file.resource_id</code>. 业务资源标识
+     */
+    public final TableField<FileRecord, String> RESOURCE_ID = createField(DSL.name("resource_id"), SQLDataType.VARCHAR(256).nullable(false).defaultValue(DSL.inline("", SQLDataType.VARCHAR)), this, "业务资源标识");
+
     private File(Name alias, Table<FileRecord> aliased) {
         this(alias, aliased, null);
     }

--- a/api/src/codegen/java/com/ke/bella/files/db/tables/pojos/FileDB.java
+++ b/api/src/codegen/java/com/ke/bella/files/db/tables/pojos/FileDB.java
@@ -46,6 +46,8 @@ public class FileDB implements Operator, Serializable {
     private String        description;
     private String        cities;
     private String        tags;
+    private String        nodeType;
+    private String        resourceId;
 
     public FileDB() {}
 
@@ -78,6 +80,8 @@ public class FileDB implements Operator, Serializable {
         this.description = value.description;
         this.cities = value.cities;
         this.tags = value.tags;
+        this.nodeType = value.nodeType;
+        this.resourceId = value.resourceId;
     }
 
     public FileDB(
@@ -108,7 +112,9 @@ public class FileDB implements Operator, Serializable {
         String        pdfFileId,
         String        description,
         String        cities,
-        String        tags
+        String        tags,
+        String        nodeType,
+        String        resourceId
     ) {
         this.id = id;
         this.fileId = fileId;
@@ -138,6 +144,8 @@ public class FileDB implements Operator, Serializable {
         this.description = description;
         this.cities = cities;
         this.tags = tags;
+        this.nodeType = nodeType;
+        this.resourceId = resourceId;
     }
 
     /**
@@ -532,6 +540,34 @@ public class FileDB implements Operator, Serializable {
         this.tags = tags;
     }
 
+    /**
+     * Getter for <code>file.node_type</code>. 节点类型：file、directory、resource
+     */
+    public String getNodeType() {
+        return this.nodeType;
+    }
+
+    /**
+     * Setter for <code>file.node_type</code>. 节点类型：file、directory、resource
+     */
+    public void setNodeType(String nodeType) {
+        this.nodeType = nodeType;
+    }
+
+    /**
+     * Getter for <code>file.resource_id</code>. 业务资源标识
+     */
+    public String getResourceId() {
+        return this.resourceId;
+    }
+
+    /**
+     * Setter for <code>file.resource_id</code>. 业务资源标识
+     */
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("FileDB (");
@@ -564,6 +600,8 @@ public class FileDB implements Operator, Serializable {
         sb.append(", ").append(description);
         sb.append(", ").append(cities);
         sb.append(", ").append(tags);
+        sb.append(", ").append(nodeType);
+        sb.append(", ").append(resourceId);
 
         sb.append(")");
         return sb.toString();

--- a/api/src/codegen/java/com/ke/bella/files/db/tables/records/FileRecord.java
+++ b/api/src/codegen/java/com/ke/bella/files/db/tables/records/FileRecord.java
@@ -413,6 +413,34 @@ public class FileRecord extends UpdatableRecordImpl<FileRecord> implements Opera
         return (String) get(27);
     }
 
+    /**
+     * Setter for <code>file.node_type</code>. 节点类型：file、directory、resource
+     */
+    public void setNodeType(String value) {
+        set(28, value);
+    }
+
+    /**
+     * Getter for <code>file.node_type</code>. 节点类型：file、directory、resource
+     */
+    public String getNodeType() {
+        return (String) get(28);
+    }
+
+    /**
+     * Setter for <code>file.resource_id</code>. 业务资源标识
+     */
+    public void setResourceId(String value) {
+        set(29, value);
+    }
+
+    /**
+     * Getter for <code>file.resource_id</code>. 业务资源标识
+     */
+    public String getResourceId() {
+        return (String) get(29);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -436,7 +464,7 @@ public class FileRecord extends UpdatableRecordImpl<FileRecord> implements Opera
     /**
      * Create a detached, initialised FileRecord
      */
-    public FileRecord(Long id, String fileId, Long version, String filename, Integer isDir, String extension, String mimeType, String type, String bucket, String path, Long bytes, String spaceCode, String purpose, Long cuid, String cuName, LocalDateTime ctime, Long muid, String muName, LocalDateTime mtime, String metaData, Integer status, String akCode, Long broadcastStatus, String domTreeFileId, String pdfFileId, String description, String cities, String tags) {
+    public FileRecord(Long id, String fileId, Long version, String filename, Integer isDir, String extension, String mimeType, String type, String bucket, String path, Long bytes, String spaceCode, String purpose, Long cuid, String cuName, LocalDateTime ctime, Long muid, String muName, LocalDateTime mtime, String metaData, Integer status, String akCode, Long broadcastStatus, String domTreeFileId, String pdfFileId, String description, String cities, String tags, String nodeType, String resourceId) {
         super(File.FILE);
 
         setId(id);
@@ -467,5 +495,7 @@ public class FileRecord extends UpdatableRecordImpl<FileRecord> implements Opera
         setDescription(description);
         setCities(cities);
         setTags(tags);
+        setNodeType(nodeType);
+        setResourceId(resourceId);
     }
 }

--- a/api/src/main/java/com/ke/bella/files/api/DatasetController.java
+++ b/api/src/main/java/com/ke/bella/files/api/DatasetController.java
@@ -36,6 +36,7 @@ import com.ke.bella.files.db.tables.pojos.DatasetDB;
 import com.ke.bella.files.db.tables.pojos.DatasetDocumentDB;
 import com.ke.bella.files.db.tables.pojos.DatasetQaDB;
 import com.ke.bella.files.db.tables.pojos.DatasetQaReferenceDB;
+import com.ke.bella.files.db.tables.pojos.FileDB;
 import com.ke.bella.files.db.tables.pojos.TagDB;
 import com.ke.bella.files.protocol.DatasetOps;
 import com.ke.bella.files.protocol.DatasetOps.DatasetImportingProgress;
@@ -183,7 +184,7 @@ public class DatasetController {
             @RequestParam(name = "type", required = false) String type,
             @RequestParam(name = "remark", required = false) String remark) {
         Assert.isTrue(fileId != null, "file_id must be provided");
-        fs.requireContentFile(fileId);
+        FileDB file = fs.requireContentFile(fileId);
 
         // step1: check dataset and init if necessary
         DatasetDB dataset = null;
@@ -210,9 +211,9 @@ public class DatasetController {
                                 .status(status.name())
                                 .percent(percent)
                                 .message(message)
-                                .build(), fileId, DATASET_IMPORT_PROGRESS);
+                                .build(), file, DATASET_IMPORT_PROGRESS);
 
-                processImport(fileId, finalDataset, progressCallback);
+                processImport(file, finalDataset, progressCallback);
             } catch (Exception e) {
                 LOGGER.error("failed to process import for file_id: {}, dataset_id: {}, e: ", fileId, finalDataset.getDatasetId(), e);
             }
@@ -221,14 +222,15 @@ public class DatasetController {
         return dataset;
     }
 
-    private DatasetDB processImport(String fileId, DatasetDB dataset, TriConsumer<DatasetImportingProgress, Integer, String> progressCallback) {
+    private DatasetDB processImport(FileDB file, DatasetDB dataset, TriConsumer<DatasetImportingProgress, Integer, String> progressCallback) {
+        String fileId = file.getFileId();
         progressCallback.accept(DatasetImportingProgress.preprocessing, 0, DatasetImportingProgress.preprocessing.getDescription());
 
         FileService.InputStreamWithCharset inputStream = null;
         try {
-            inputStream = fs.getFileInputStream(fileId);
+            inputStream = fs.getFileInputStream(file);
 
-            String fileName = fs.getFile(fileId).getFilename();
+            String fileName = file.getFilename();
             Assert.hasText(fileName, "file name must not be empty. file_id: " + fileId);
 
             boolean isExcel = (fileName.toLowerCase().endsWith(".xlsx") || fileName.toLowerCase().endsWith(".xls"));

--- a/api/src/main/java/com/ke/bella/files/api/DatasetController.java
+++ b/api/src/main/java/com/ke/bella/files/api/DatasetController.java
@@ -183,6 +183,7 @@ public class DatasetController {
             @RequestParam(name = "type", required = false) String type,
             @RequestParam(name = "remark", required = false) String remark) {
         Assert.isTrue(fileId != null, "file_id must be provided");
+        fs.requireContentFile(fileId);
 
         // step1: check dataset and init if necessary
         DatasetDB dataset = null;

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -43,6 +43,7 @@ import com.ke.bella.files.annotations.FileAPI;
 import com.ke.bella.files.db.repo.Page;
 import com.ke.bella.files.db.tables.pojos.FileDB;
 import com.ke.bella.files.enums.FilePurpose;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.DomTreeOps.DomTreeUploadOp;
 import com.ke.bella.files.protocol.FileAncestorIdsOps;
 import com.ke.bella.files.protocol.FileCropOps;
@@ -53,6 +54,7 @@ import com.ke.bella.files.protocol.FileExists;
 import com.ke.bella.files.protocol.FileMoveOps;
 import com.ke.bella.files.protocol.FileOps;
 import com.ke.bella.files.protocol.FileSystemOps.MkdirOp;
+import com.ke.bella.files.protocol.FileSystemOps.CreateResourceOp;
 import com.ke.bella.files.protocol.FileUrl;
 import com.ke.bella.files.protocol.ListFileOps;
 import com.ke.bella.files.protocol.OpenAIFile;
@@ -96,6 +98,8 @@ public class FileController {
 
     private static final Pattern UNIX_INVALID_CHARS = Pattern.compile("[\\x00/]");
 
+    private static final Pattern RESOURCE_ID_PATTERN = Pattern.compile("^[^:]+:.+$");
+
     @Autowired
     FileService fileService;
     @Autowired
@@ -134,6 +138,7 @@ public class FileController {
         TmpFileInfo tmpFileInfo = null;
         final String spaceCode = BellaContextHelper.getOperateSpaceCode();
         final String filename = file.getOriginalFilename();
+        validateAncestorDirectory(spaceCode, ancestorId);
 
         // 提取文件元数据
         MediaType mimeTypeSource = Optional.ofNullable(file.getContentType()).map(MediaType::parse).orElse(null);
@@ -431,6 +436,27 @@ public class FileController {
 
     }
 
+    private void validateResourceId(String resourceId) {
+        Assert.hasText(resourceId, "resource_id is required");
+        Assert.isTrue(resourceId.length() <= 256, "resource_id cannot exceed 256 characters");
+        Assert.isTrue(resourceId.equals(resourceId.trim()), "resource_id cannot start or end with whitespace");
+        Assert.isTrue(RESOURCE_ID_PATTERN.matcher(resourceId).matches(),
+                "resource_id must match '<namespace>:<business-id>'");
+    }
+
+    private void validateAncestorDirectory(String spaceCode, String ancestorId) {
+        if(StringUtils.isEmpty(ancestorId)) {
+            return;
+        }
+        FileDB ancestor = fileService.getFile0(ancestorId);
+        if(ancestor == null) {
+            throw new FileNotFoundException(ancestorId);
+        }
+        Assert.isTrue(NodeType.from(ancestor) == NodeType.DIRECTORY, "ancestor_id must refer to a directory");
+        Assert.isTrue(StringUtils.equals(spaceCode, ancestor.getSpaceCode()),
+                "space_code mismatch between context and ancestor_id");
+    }
+
     @GetMapping("/{file_id}")
     public OpenAIFile get(@PathVariable("file_id") String fileId,
             @RequestParam(value = "get_url", required = false, defaultValue = "false") boolean getUrl,
@@ -492,7 +518,7 @@ public class FileController {
                             String.format("File '%s' already exists in current directory, %s", filename, location));
                 }
 
-                String extension = FileUtils.getFileExtension(filename);
+                String extension = NodeType.RESOURCE.getValue().equals(existingFile.getNodeType()) ? "" : FileUtils.getFileExtension(filename);
 
                 FileOps ops = FileOps.builder()
                         .fileId(fileId)
@@ -517,10 +543,7 @@ public class FileController {
             throw new IllegalArgumentException("file_id is required, but not provided");
         }
 
-        OpenAIFile existingFile = fileService.getFile(fileId);
-        if(existingFile == null) {
-            throw new FileNotFoundException(fileId);
-        }
+        OpenAIFile existingFile = fileService.requireContentFile(fileId);
 
         // 提取文件元数据
         MediaType mimeTypeSource = Optional.ofNullable(file.getContentType()).map(MediaType::parse).orElse(null);
@@ -591,6 +614,7 @@ public class FileController {
         if(StringUtils.isEmpty(sourceFileId)) {
             throw new IllegalArgumentException("file_id is required, but not provided");
         }
+        fileService.requireContentFile(sourceFileId);
 
         final String filename = String.format("dom_tree_%s.json", sourceFileId);
         final String spaceCode = BellaContextHelper.getOperateSpaceCode();
@@ -629,6 +653,7 @@ public class FileController {
         if(StringUtils.isEmpty(domTreeUploadOp.getFileId())) {
             throw new IllegalArgumentException("file_id is required, but not provided");
         }
+        fileService.requireContentFile(domTreeUploadOp.getFileId());
         if(domTreeUploadOp.getDomTree() == null) {
             throw new IllegalArgumentException("dom_tree_content is required, but not provided");
         }
@@ -659,10 +684,7 @@ public class FileController {
     public void retrieveDomTreeContent(
             HttpServletResponse response,
             @PathVariable("file_id") String fileId) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
+        OpenAIFile file = fileService.requireContentFile(fileId);
 
         String targetFileId;
         if("dom_tree".equals(file.getPurpose())) {
@@ -683,10 +705,7 @@ public class FileController {
     public FileUrl getDomTreeUrl(
             @PathVariable("file_id") String fileId,
             @RequestParam(value = "expires", required = false, defaultValue = ONE_DAY_STRING) Long expires) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
+        OpenAIFile file = fileService.requireContentFile(fileId);
 
         String targetFileId;
         if("dom_tree".equals(file.getPurpose())) {
@@ -711,6 +730,7 @@ public class FileController {
         if(StringUtils.isEmpty(sourceFileId)) {
             throw new IllegalArgumentException("file_id is required, but not provided");
         }
+        fileService.requireContentFile(sourceFileId);
 
         final String filename = String.format("pdf_%s.pdf", sourceFileId);
         final String spaceCode = BellaContextHelper.getOperateSpaceCode();
@@ -770,10 +790,7 @@ public class FileController {
     public void retrieveContentRedirect(
             HttpServletResponse response,
             @PathVariable("file_id") String fileId) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
+        fileService.requireContentFile(fileId);
         String redirectUrl = fileService.getUrl(fileId);
         response.setHeader(HttpHeaders.LOCATION, redirectUrl);
         response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
@@ -783,11 +800,7 @@ public class FileController {
     public FileUrl getUrl(
             @PathVariable("file_id") String fileId,
             @RequestParam(value = "expires", required = false, defaultValue = ONE_DAY_STRING) Long expires) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
-        Assert.isTrue(!file.getIsDir(), String.format("file is a directory, not a file. file_id = %s", fileId));
+        fileService.requireContentFile(fileId);
         String url = fileService.getUrl(fileId, expires);
         return FileUrl.builder()
                 .url(url)
@@ -799,10 +812,7 @@ public class FileController {
             @RequestBody UpdateProgressRequestData data,
             @PathVariable("file_id") String fileId,
             @PathVariable("progress_name") String progressName) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
+        OpenAIFile file = fileService.requireContentFile(fileId);
         String purpose = file.getPurpose();
         if(!FilePurposeClassifier.allowedProgressTrackablePurposes().contains(purpose)) {
             throw new IllegalArgumentException(String.format(
@@ -819,10 +829,7 @@ public class FileController {
     public Progress getProgress(
             @PathVariable("file_id") String fileId,
             @RequestParam("progress_name") String progressName) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
+        OpenAIFile file = fileService.requireContentFile(fileId);
         String purpose = file.getPurpose();
         if(!FilePurposeClassifier.allowedProgressTrackablePurposes().contains(purpose)) {
             throw new IllegalArgumentException(String.format(
@@ -861,11 +868,7 @@ public class FileController {
     public FileUrl getPreviewUrl(
             @PathVariable("file_id") String fileId,
             @RequestParam(value = "expires", required = false, defaultValue = ONE_DAY_STRING) Long expires) {
-        OpenAIFile file = fileService.getFile(fileId);
-        if(file == null) {
-            throw new FileNotFoundException(fileId);
-        }
-        Assert.isTrue(!file.getIsDir(), String.format("file is a directory, not a file. file_id = %s", fileId));
+        OpenAIFile file = fileService.requireContentFile(fileId);
 
         String url;
         if(!StringUtils.isEmpty(file.getPdfFileId())) {
@@ -917,9 +920,7 @@ public class FileController {
         Assert.isTrue(bbox.size() == 4, "bbox must have exactly 4 values: [x1, y1, x2, y2]");
 
         // 校验文件存在
-        OpenAIFile file = fileService.getFile(fileId);;
-        Assert.notNull(file, String.format("file not found. file_id = %s", fileId));
-        Assert.isTrue(!file.getIsDir(), String.format("file is a directory, not a file. file_id = %s", fileId));
+        OpenAIFile file = fileService.requireContentFile(fileId);
 
         // 确认要处理的pdf文件
         String pdfFileId = fileId;
@@ -1045,6 +1046,7 @@ public class FileController {
         }
 
         String spaceCode = BellaContextHelper.getOperateSpaceCode();
+        validateAncestorDirectory(spaceCode, op.getAncestorId());
 
         return fl.executeWithLock(spaceCode, op.getAncestorId(), op.getName(), FILE_LOCK_TIMEOUT_MS, () -> {
             if(fileService.exists(spaceCode, op.getAncestorId(), op.getName())) {
@@ -1053,6 +1055,24 @@ public class FileController {
             }
 
             return fileService.mkdir(op.getName(), op.getAncestorId(), op.getDescription(), op.getPurpose());
+        });
+    }
+
+    @PostMapping("/resources")
+    public OpenAIFile createResource(@RequestBody CreateResourceOp op) {
+        Assert.notNull(op, "invalid request body");
+        validateDirectoryName(op.getName());
+        validateResourceId(op.getResourceId());
+
+        String spaceCode = BellaContextHelper.getOperateSpaceCode();
+        validateAncestorDirectory(spaceCode, op.getAncestorId());
+
+        return fl.executeWithLock(spaceCode, op.getAncestorId(), op.getName(), FILE_LOCK_TIMEOUT_MS, () -> {
+            if(fileService.exists(spaceCode, op.getAncestorId(), op.getName())) {
+                throw new IllegalArgumentException(
+                        String.format("Resource '%s' already exists in current directory, ancestor_id: '%s'", op.getName(), op.getAncestorId()));
+            }
+            return fileService.createResource(op.getName(), op.getResourceId(), op.getAncestorId());
         });
     }
 
@@ -1070,6 +1090,7 @@ public class FileController {
             if(ancestor == null) {
                 throw new IllegalArgumentException("File not found. file_id = " + ancestorId);
             }
+            Assert.isTrue(NodeType.from(ancestor) == NodeType.DIRECTORY, "ancestor_id must refer to a directory");
             files = fileService.findFiles(ancestor);
         } else {
             files = fileService.findFiles(spaceCode);
@@ -1110,6 +1131,8 @@ public class FileController {
         if(existingFile == null) {
             throw new FileNotFoundException(fileId);
         }
+        Assert.isTrue(!NodeType.RESOURCE.getValue().equals(existingFile.getNodeType()),
+                "resource nodes do not support descriptions");
 
         FileOps ops = FileOps.builder()
                 .fileId(fileId)
@@ -1144,6 +1167,8 @@ public class FileController {
         if(existingFile == null) {
             throw new FileNotFoundException(fileId);
         }
+        Assert.isTrue(!NodeType.RESOURCE.getValue().equals(existingFile.getNodeType()),
+                "resource nodes do not support cities");
 
         FileOps ops = FileOps.builder()
                 .fileId(fileId)
@@ -1178,6 +1203,8 @@ public class FileController {
         if(existingFile == null) {
             throw new FileNotFoundException(fileId);
         }
+        Assert.isTrue(!NodeType.RESOURCE.getValue().equals(existingFile.getNodeType()),
+                "resource nodes do not support tags");
 
         FileOps ops = FileOps.builder()
                 .fileId(fileId)
@@ -1214,7 +1241,7 @@ public class FileController {
             if(ancestor == null) {
                 throw new FileNotFoundException(targetAncestorId);
             }
-            Assert.isTrue(ancestor.getIsDir() == 1, "ancestor_id must refer to a directory");
+            Assert.isTrue(NodeType.from(ancestor) == NodeType.DIRECTORY, "ancestor_id must refer to a directory");
             Assert.isTrue(StringUtils.equals(spaceCode, ancestor.getSpaceCode()),
                     "space_code mismatch between context and ancestor_id");
         }
@@ -1226,7 +1253,7 @@ public class FileController {
         Assert.isTrue(StringUtils.equals(spaceCode, file.getSpaceCode()), "space mismatch between context and file_id");
 
         try {
-            boolean directory = file.getIsDir() == 1;
+            boolean directory = NodeType.from(file) == NodeType.DIRECTORY;
             return fl.executeWithMoveLock(spaceCode, directory, FILE_LOCK_TIMEOUT_MS,
                     () -> fl.executeWithLock(spaceCode, targetAncestorId, file.getFilename(), FILE_LOCK_TIMEOUT_MS,
                             () -> {
@@ -1254,9 +1281,17 @@ public class FileController {
         // 校验spaceCode和ancestorId至少提供一个
         Assert.isTrue(StringUtils.isNotEmpty(ops.getSpaceCode()) || StringUtils.isNotEmpty(ops.getAncestorId()),
                 "either space_code or ancestor_id must be provided");
+        if(StringUtils.isNotEmpty(ops.getAncestorId())) {
+            FileDB ancestor = fileService.getFile0(ops.getAncestorId());
+            if(ancestor == null) {
+                throw new FileNotFoundException(ops.getAncestorId());
+            }
+            Assert.isTrue(NodeType.from(ancestor) == NodeType.DIRECTORY, "ancestor_id must refer to a directory");
+        }
         // type 为可选参数，如果提供则必须是 dir 或 file
         if(ops.getType() != null) {
-            Assert.isTrue("dir".equals(ops.getType()) || "file".equals(ops.getType()), "type must be 'dir' or 'file', but got: " + ops.getType());
+            Assert.isTrue("dir".equals(ops.getType()) || "file".equals(ops.getType()) || "resource".equals(ops.getType()),
+                    "type must be 'dir', 'file' or 'resource', but got: " + ops.getType());
         }
         Assert.isTrue(ops.getPage() >= 1, "page must be greater than 0");
         Assert.isTrue(ops.getPageSize() >= 1, "page_size must be greater than 0");

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1061,12 +1061,19 @@ public class FileController {
     /**
      * 创建业务资源引用。resource_id 有意不做唯一性校验，支持将同一业务资源登记到多个目录位置；
      * 删除其中一个节点只移除该处引用，不影响其他引用或业务系统中的原始资源。
+     * purpose 为可选字段，取值范围与文件和目录创建接口一致。
      */
     @PostMapping("/resources")
     public OpenAIFile createResource(@RequestBody CreateResourceOp op) {
         Assert.notNull(op, "invalid request body");
         validateDirectoryName(op.getName());
         validateResourceId(op.getResourceId());
+        if(op.getPurpose() != null && !FilePurposeClassifier.allowedPurposes().contains(op.getPurpose())) {
+            throw new IllegalArgumentException(
+                    String.format("Unsupported purpose: '%s'. Supported purposes are: %s",
+                            op.getPurpose(),
+                            String.join(", ", FilePurposeClassifier.allowedPurposes())));
+        }
 
         String spaceCode = BellaContextHelper.getOperateSpaceCode();
         validateAncestorDirectory(spaceCode, op.getAncestorId());
@@ -1076,7 +1083,7 @@ public class FileController {
                 throw new IllegalArgumentException(
                         String.format("Resource '%s' already exists in current directory, ancestor_id: '%s'", op.getName(), op.getAncestorId()));
             }
-            return fileService.createResource(op.getName(), op.getResourceId(), op.getAncestorId());
+            return fileService.createResource(op.getName(), op.getResourceId(), op.getAncestorId(), op.getPurpose());
         });
     }
 

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -543,7 +543,7 @@ public class FileController {
             throw new IllegalArgumentException("file_id is required, but not provided");
         }
 
-        OpenAIFile existingFile = fileService.requireContentFile(fileId);
+        FileDB existingFile = fileService.requireContentFile(fileId);
 
         // 提取文件元数据
         MediaType mimeTypeSource = Optional.ofNullable(file.getContentType()).map(MediaType::parse).orElse(null);
@@ -559,8 +559,8 @@ public class FileController {
         String extension = FileUtils.getFileExtension(filename);
 
         try (InputStream inputStream = file.getInputStream()) {
-            return updateFileFromStream(fileId, inputStream, file.getSize(), existingFile.getFilename(),
-                    type, mimeType, extension, charset, existingFile.getMetadata(), existingFile.getPurpose());
+            return updateFileFromStream(existingFile, inputStream, file.getSize(), existingFile.getFilename(),
+                    type, mimeType, extension, charset, existingFile.getMetaData(), existingFile.getPurpose());
         } catch (Exception e) {
             LOGGER.error("File update failed, file_id: {}, error: {}", fileId, e.getMessage(), e);
             throw new IllegalStateException("File update failed", e);
@@ -589,8 +589,14 @@ public class FileController {
 
     private OpenAIFile updateFileFromStream(String fileId, InputStream inputStream, long contentLength, String filename,
             String type, String mimeType, String extension, String charset, String metadata, String purpose) {
+        return updateFileFromStream(fileService.requireContentFile(fileId), inputStream, contentLength, filename,
+                type, mimeType, extension, charset, metadata, purpose);
+    }
 
-        String fileKey = fileService.updateRealFileFromStream(fileId, filename, inputStream, contentLength, mimeType, charset);
+    private OpenAIFile updateFileFromStream(FileDB file, InputStream inputStream, long contentLength, String filename,
+            String type, String mimeType, String extension, String charset, String metadata, String purpose) {
+        String fileId = file.getFileId();
+        String fileKey = fileService.updateRealFileFromStream(file, filename, inputStream, contentLength, mimeType, charset);
 
         FileOps ops = FileOps.builder()
                 .fileId(fileId)
@@ -684,11 +690,11 @@ public class FileController {
     public void retrieveDomTreeContent(
             HttpServletResponse response,
             @PathVariable("file_id") String fileId) {
-        OpenAIFile file = fileService.requireContentFile(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
 
         String targetFileId;
         if("dom_tree".equals(file.getPurpose())) {
-            targetFileId = file.getId();
+            targetFileId = file.getFileId();
         } else if(!StringUtils.isEmpty(file.getDomTreeFileId())) {
             targetFileId = file.getDomTreeFileId();
         } else {
@@ -696,7 +702,9 @@ public class FileController {
                     String.format("the file does not have a legal dom file. file_id = %s", fileId));
         }
 
-        String redirectUrl = fileService.getUrl(targetFileId);
+        String redirectUrl = targetFileId.equals(file.getFileId())
+                ? fileService.getUrl(file, FileService.ONE_DAY)
+                : fileService.getUrl(targetFileId);
         response.setHeader(HttpHeaders.LOCATION, redirectUrl);
         response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
     }
@@ -705,11 +713,11 @@ public class FileController {
     public FileUrl getDomTreeUrl(
             @PathVariable("file_id") String fileId,
             @RequestParam(value = "expires", required = false, defaultValue = ONE_DAY_STRING) Long expires) {
-        OpenAIFile file = fileService.requireContentFile(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
 
         String targetFileId;
         if("dom_tree".equals(file.getPurpose())) {
-            targetFileId = file.getId();
+            targetFileId = file.getFileId();
         } else if(!StringUtils.isEmpty(file.getDomTreeFileId())) {
             targetFileId = file.getDomTreeFileId();
         } else {
@@ -717,7 +725,9 @@ public class FileController {
                     String.format("the file does not have a legal dom file. file_id = %s", fileId));
         }
 
-        String url = fileService.getUrl(targetFileId, expires);
+        String url = targetFileId.equals(file.getFileId())
+                ? fileService.getUrl(file, expires)
+                : fileService.getUrl(targetFileId, expires);
         return FileUrl.builder()
                 .url(url)
                 .build();
@@ -790,8 +800,8 @@ public class FileController {
     public void retrieveContentRedirect(
             HttpServletResponse response,
             @PathVariable("file_id") String fileId) {
-        fileService.requireContentFile(fileId);
-        String redirectUrl = fileService.getUrl(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
+        String redirectUrl = fileService.getUrl(file, FileService.ONE_DAY);
         response.setHeader(HttpHeaders.LOCATION, redirectUrl);
         response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
     }
@@ -800,8 +810,8 @@ public class FileController {
     public FileUrl getUrl(
             @PathVariable("file_id") String fileId,
             @RequestParam(value = "expires", required = false, defaultValue = ONE_DAY_STRING) Long expires) {
-        fileService.requireContentFile(fileId);
-        String url = fileService.getUrl(fileId, expires);
+        FileDB file = fileService.requireContentFile(fileId);
+        String url = fileService.getUrl(file, expires);
         return FileUrl.builder()
                 .url(url)
                 .build();
@@ -812,7 +822,7 @@ public class FileController {
             @RequestBody UpdateProgressRequestData data,
             @PathVariable("file_id") String fileId,
             @PathVariable("progress_name") String progressName) {
-        OpenAIFile file = fileService.requireContentFile(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
         String purpose = file.getPurpose();
         if(!FilePurposeClassifier.allowedProgressTrackablePurposes().contains(purpose)) {
             throw new IllegalArgumentException(String.format(
@@ -821,15 +831,15 @@ public class FileController {
                     String.join(", ", FilePurposeClassifier.allowedProgressTrackablePurposes()),
                     fileId));
         }
-        fileService.updateProgress(data, fileId, progressName);
-        return fileService.getProgress(fileId, progressName);
+        fileService.updateProgress(data, file, progressName);
+        return fileService.getProgress(file, progressName);
     }
 
     @GetMapping("/{file_id}/progress")
     public Progress getProgress(
             @PathVariable("file_id") String fileId,
             @RequestParam("progress_name") String progressName) {
-        OpenAIFile file = fileService.requireContentFile(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
         String purpose = file.getPurpose();
         if(!FilePurposeClassifier.allowedProgressTrackablePurposes().contains(purpose)) {
             throw new IllegalArgumentException(String.format(
@@ -838,7 +848,7 @@ public class FileController {
                     String.join(", ", FilePurposeClassifier.allowedProgressTrackablePurposes()),
                     fileId));
         }
-        Progress res = fileService.getProgress(fileId, progressName);
+        Progress res = fileService.getProgress(file, progressName);
         if(res == null) {
             throw new ProgressNotFoundException(fileId, progressName);
         }
@@ -868,16 +878,16 @@ public class FileController {
     public FileUrl getPreviewUrl(
             @PathVariable("file_id") String fileId,
             @RequestParam(value = "expires", required = false, defaultValue = ONE_DAY_STRING) Long expires) {
-        OpenAIFile file = fileService.requireContentFile(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
 
         String url;
         if(!StringUtils.isEmpty(file.getPdfFileId())) {
             url = fileService.getUrl(file.getPdfFileId(), expires);
             // fixme: doc、docx 历史数据不存在转换回流的pdf，需要刷数后才能下掉
         } else if("doc".equals(file.getExtension()) || "docx".equals(file.getExtension())) {
-            url = fileService.getPreviewUrl(file.getId(), expires);
+            url = fileService.getPreviewUrl(file, expires);
         } else {
-            url = fileService.getUrl(fileId, expires);
+            url = fileService.getUrl(file, expires);
         }
         return FileUrl
                 .builder()
@@ -920,7 +930,7 @@ public class FileController {
         Assert.isTrue(bbox.size() == 4, "bbox must have exactly 4 values: [x1, y1, x2, y2]");
 
         // 校验文件存在
-        OpenAIFile file = fileService.requireContentFile(fileId);
+        FileDB file = fileService.requireContentFile(fileId);
 
         // 确认要处理的pdf文件
         String pdfFileId = fileId;
@@ -938,7 +948,9 @@ public class FileController {
         double x2 = bbox.get(2);
         double y2 = bbox.get(3);
 
-        FileService.InputStreamWithCharset streamWithCharset = fileService.getFileInputStream(pdfFileId);
+        FileService.InputStreamWithCharset streamWithCharset = pdfFileId.equals(file.getFileId())
+                ? fileService.getFileInputStream(file)
+                : fileService.getFileInputStream(pdfFileId);
         BufferedImage pageImage = null;
         BufferedImage croppedImage = null;
         ByteArrayOutputStream baos = null;

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1058,6 +1058,10 @@ public class FileController {
         });
     }
 
+    /**
+     * 创建业务资源引用。resource_id 有意不做唯一性校验，支持将同一业务资源登记到多个目录位置；
+     * 删除其中一个节点只移除该处引用，不影响其他引用或业务系统中的原始资源。
+     */
     @PostMapping("/resources")
     public OpenAIFile createResource(@RequestBody CreateResourceOp op) {
         Assert.notNull(op, "invalid request body");

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -822,11 +822,13 @@ public class FileRepo implements BaseRepo {
             fileCondition = fileCondition.and(FILE.SPACE_CODE.eq(ops.getSpaceCode()));
         }
         if("dir".equals(ops.getType())) {
-            fileCondition = fileCondition.and(FILE.NODE_TYPE.eq(NodeType.DIRECTORY.getValue()));
+            fileCondition = fileCondition.and(FILE.IS_DIR.eq(1));
         } else if("file".equals(ops.getType())) {
-            fileCondition = fileCondition.and(FILE.NODE_TYPE.eq(NodeType.FILE.getValue()));
+            fileCondition = fileCondition.and(FILE.IS_DIR.eq(0))
+                    .and(FILE.NODE_TYPE.eq(NodeType.FILE.getValue()));
         } else if("resource".equals(ops.getType())) {
-            fileCondition = fileCondition.and(FILE.NODE_TYPE.eq(NodeType.RESOURCE.getValue()));
+            fileCondition = fileCondition.and(FILE.IS_DIR.eq(0))
+                    .and(FILE.NODE_TYPE.eq(NodeType.RESOURCE.getValue()));
         }
         if(ops.getPurpose() != null) {
             fileCondition = fileCondition.and(FILE.PURPOSE.eq(ops.getPurpose()));

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -51,6 +51,7 @@ import com.ke.bella.files.db.tables.records.FileProgressRecord;
 import com.ke.bella.files.db.tables.records.FileRecord;
 import com.ke.bella.files.db.tables.records.FileShardingRecord;
 import com.ke.bella.files.enums.FileType;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.FileException.FileNotFoundException;
 import com.ke.bella.files.protocol.FileOps;
 import com.ke.bella.files.protocol.FileStatus;
@@ -175,6 +176,7 @@ public class FileRepo implements BaseRepo {
                 .innerJoin(FILE)
                 .on(FILE_CLOSURE.DESCENDANT_ID.eq(FILE.FILE_ID))
                 .where(FILE.FILENAME.eq(filename))
+                .and(FILE.STATUS.eq(FileStatus.NOT_DELETED.getValue()))
                 .and(FILE_CLOSURE.SPACE_CODE.eq(spaceCode));
 
         if(StringUtils.isEmpty(ancestorId)) {
@@ -195,6 +197,7 @@ public class FileRepo implements BaseRepo {
                 .innerJoin(FILE)
                 .on(FILE_CLOSURE.DESCENDANT_ID.eq(FILE.FILE_ID))
                 .where(FILE_CLOSURE.SPACE_CODE.eq(spaceCode))
+                .and(FILE.STATUS.eq(FileStatus.NOT_DELETED.getValue()))
                 .and(FILE.FILENAME.eq(filename));
 
         if(StringUtils.isEmpty(ancestorId)) {
@@ -313,7 +316,9 @@ public class FileRepo implements BaseRepo {
                 .innerJoin(FILE)
                 .on(FILE_CLOSURE.DESCENDANT_ID.eq(FILE.FILE_ID))
                 .where(FILE.SPACE_CODE.eq(spaceCode))
-                .and(FILE_CLOSURE.SPACE_CODE.eq(spaceCode));
+                .and(FILE_CLOSURE.SPACE_CODE.eq(spaceCode))
+                .and(FILE.STATUS.eq(FileStatus.NOT_DELETED.getValue()))
+                .and(FILE.NODE_TYPE.ne(NodeType.RESOURCE.getValue()));
 
         if(StringUtils.isEmpty(ancestorId)) {
             query.and(FILE_CLOSURE.ROOT_DEPTH.eq(1L));
@@ -668,7 +673,8 @@ public class FileRepo implements BaseRepo {
                 .innerJoin(FILE)
                 .on(FILE_CLOSURE.DESCENDANT_ID.eq(FILE.FILE_ID))
                 .where(FILE.SPACE_CODE.eq(spaceCode))
-                .and(FILE_CLOSURE.SPACE_CODE.eq(spaceCode));
+                .and(FILE_CLOSURE.SPACE_CODE.eq(spaceCode))
+                .and(FILE.STATUS.eq(FileStatus.NOT_DELETED.getValue()));
 
         if(StringUtils.isEmpty(ancestorId)) {
             query.and(FILE_CLOSURE.ROOT_DEPTH.eq(1L));
@@ -816,9 +822,11 @@ public class FileRepo implements BaseRepo {
             fileCondition = fileCondition.and(FILE.SPACE_CODE.eq(ops.getSpaceCode()));
         }
         if("dir".equals(ops.getType())) {
-            fileCondition = fileCondition.and(FILE.IS_DIR.eq(1));
+            fileCondition = fileCondition.and(FILE.NODE_TYPE.eq(NodeType.DIRECTORY.getValue()));
         } else if("file".equals(ops.getType())) {
-            fileCondition = fileCondition.and(FILE.IS_DIR.eq(0));
+            fileCondition = fileCondition.and(FILE.NODE_TYPE.eq(NodeType.FILE.getValue()));
+        } else if("resource".equals(ops.getType())) {
+            fileCondition = fileCondition.and(FILE.NODE_TYPE.eq(NodeType.RESOURCE.getValue()));
         }
         if(ops.getPurpose() != null) {
             fileCondition = fileCondition.and(FILE.PURPOSE.eq(ops.getPurpose()));

--- a/api/src/main/java/com/ke/bella/files/enums/NodeType.java
+++ b/api/src/main/java/com/ke/bella/files/enums/NodeType.java
@@ -1,0 +1,33 @@
+package com.ke.bella.files.enums;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.ke.bella.files.db.tables.pojos.FileDB;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NodeType {
+    FILE("file"),
+    DIRECTORY("directory"),
+    RESOURCE("resource");
+
+    private final String value;
+
+    public static NodeType from(FileDB file) {
+        if(file == null) {
+            return null;
+        }
+        if(StringUtils.isNotEmpty(file.getNodeType())) {
+            for (NodeType nodeType : values()) {
+                if(nodeType.value.equals(file.getNodeType())) {
+                    return nodeType;
+                }
+            }
+            throw new IllegalStateException("Unsupported node_type: " + file.getNodeType());
+        }
+        return Integer.valueOf(1).equals(file.getIsDir()) ? DIRECTORY : FILE;
+    }
+}

--- a/api/src/main/java/com/ke/bella/files/enums/NodeType.java
+++ b/api/src/main/java/com/ke/bella/files/enums/NodeType.java
@@ -20,6 +20,9 @@ public enum NodeType {
         if(file == null) {
             return null;
         }
+        if(Integer.valueOf(1).equals(file.getIsDir())) {
+            return DIRECTORY;
+        }
         if(StringUtils.isNotEmpty(file.getNodeType())) {
             for (NodeType nodeType : values()) {
                 if(nodeType.value.equals(file.getNodeType())) {
@@ -28,6 +31,6 @@ public enum NodeType {
             }
             throw new IllegalStateException("Unsupported node_type: " + file.getNodeType());
         }
-        return Integer.valueOf(1).equals(file.getIsDir()) ? DIRECTORY : FILE;
+        return FILE;
     }
 }

--- a/api/src/main/java/com/ke/bella/files/protocol/FileSystemOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/FileSystemOps.java
@@ -35,6 +35,16 @@ public class FileSystemOps {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    public static class CreateResourceOp {
+        private String ancestorId;
+        private String name;
+        private String resourceId;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
     public static class FindOp {
         private String name;
         private List<String> types;

--- a/api/src/main/java/com/ke/bella/files/protocol/FileSystemOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/FileSystemOps.java
@@ -39,6 +39,7 @@ public class FileSystemOps {
         private String ancestorId;
         private String name;
         private String resourceId;
+        private String purpose;
     }
 
     @Data

--- a/api/src/main/java/com/ke/bella/files/protocol/OpenAIFile.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/OpenAIFile.java
@@ -22,6 +22,8 @@ public class OpenAIFile {
     private Long createdAt;
     private String filename;
     private Boolean isDir;
+    private String nodeType;
+    private String resourceId;
     /**
      * assistants
      * assistants_output

--- a/api/src/main/java/com/ke/bella/files/protocol/PageFileOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/PageFileOps.java
@@ -65,7 +65,7 @@ public class PageFileOps {
      */
     private String filename;
     /**
-     * 类型过滤：file（仅文件）、dir（仅目录）
+     * 类型过滤：file（仅内容文件）、dir（仅目录）、resource（仅资源）
      */
     private String type;
     /**

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -660,7 +660,7 @@ public class FileService {
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public OpenAIFile createResource(String name, String resourceId, String ancestorId) {
+    public OpenAIFile createResource(String name, String resourceId, String ancestorId, String purpose) {
         String spaceCode = BellaContextHelper.getOperateSpaceCode();
         String fileId = FILE_ID_GENERATOR.generateWithType(FileType.USER);
 
@@ -674,7 +674,7 @@ public class FileService {
         fileDB.setPath("");
         fileDB.setBytes(0L);
         fileDB.setSpaceCode(spaceCode);
-        fileDB.setPurpose("");
+        fileDB.setPurpose(StringUtils.defaultString(purpose));
         fileDB.setMetaData("{}");
         fileDB.setAkCode(BellaContextHelper.getOperatorAkCode());
         fileDB.setIsDir(0);

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -696,7 +696,18 @@ public class FileService {
         if(created == null) {
             throw new FileNotFoundException(fileId);
         }
-        return transferToOpenAIFile(created);
+        OpenAIFile resource = transferToOpenAIFile(created);
+
+        FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
+        message.setEvent(EventType.FILE_CREATED);
+        message.setData(resource);
+        message.setMetadata("{}");
+        message.setUserId(BellaContextHelper.getOperatorUserId());
+        message.setUserName(BellaContextHelper.getOperatorUserName());
+        message.setAkCode(BellaContextHelper.getOperatorAkCode());
+        broadcastService.broadcast(message, () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
+                () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
+        return resource;
     }
 
     public List<OpenAIFile> findFiles(FileDB ancestor) {

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -437,11 +437,16 @@ public class FileService {
         return transferToOpenAIFile(fileDB);
     }
 
-    public OpenAIFile requireContentFile(String fileId) {
-        OpenAIFile file = getFile(fileId);
-        if(!NodeType.FILE.getValue().equals(file.getNodeType())) {
+    public FileDB requireContentFile(String fileId) {
+        FileType fileType = FileType.fromFileId(fileId);
+        FileDB file = fileRepo.queryFile(fileId, fileType);
+        if(file == null) {
+            throw new FileNotFoundException(fileId);
+        }
+        NodeType nodeType = NodeType.from(file);
+        if(nodeType != NodeType.FILE) {
             throw new IllegalArgumentException(String.format("node has no file content. file_id = %s, node_type = %s",
-                    fileId, file.getNodeType()));
+                    fileId, nodeType.getValue()));
         }
         return file;
     }
@@ -452,16 +457,20 @@ public class FileService {
     }
 
     public String updateRealFile(String fileId, String filename, File file, String mimeType, String charset) {
-        requireContentFile(fileId);
-        FileType fileType = FileType.fromFileId(fileId);
-        FileDB fileDB = fileRepo.queryFile(fileId, fileType);
+        return updateRealFile(requireContentFile(fileId), filename, file, mimeType, charset);
+    }
+
+    public String updateRealFile(FileDB fileDB, String filename, File file, String mimeType, String charset) {
         return storageService.putObject(fileDB.getBucket(), fileDB.getPath(), mimeType, file, filename, charset);
     }
 
     public String updateRealFileFromStream(String fileId, String filename, java.io.InputStream inputStream, long contentLength, String mimeType,
             String charset) {
-        requireContentFile(fileId);
-        FileDB fileDB = fileRepo.queryFile(fileId);
+        return updateRealFileFromStream(requireContentFile(fileId), filename, inputStream, contentLength, mimeType, charset);
+    }
+
+    public String updateRealFileFromStream(FileDB fileDB, String filename, java.io.InputStream inputStream, long contentLength, String mimeType,
+            String charset) {
         return storageService.putObjectFromStream(fileDB.getBucket(), fileDB.getPath(), mimeType, inputStream, contentLength, filename, charset);
     }
 
@@ -535,8 +544,10 @@ public class FileService {
     public String getUrl(
             String fileId,
             long expires) {
-        requireContentFile(fileId);
-        FileDB file = fileRepo.queryFile(fileId);
+        return getUrl(requireContentFile(fileId), expires);
+    }
+
+    public String getUrl(FileDB file, long expires) {
         return getUrl(file.getBucket(), file.getPath(), file.getPurpose(), expires);
     }
 
@@ -549,7 +560,14 @@ public class FileService {
             UpdateProgressRequestData data,
             String fileId,
             String progressName) {
-        requireContentFile(fileId);
+        updateProgress(data, requireContentFile(fileId), progressName);
+    }
+
+    public void updateProgress(
+            UpdateProgressRequestData data,
+            FileDB file,
+            String progressName) {
+        String fileId = file.getFileId();
         String status = data.getStatus();
         String message = data.getMessage();
         Integer percent = data.getPercent();
@@ -563,8 +581,13 @@ public class FileService {
     public Progress getProgress(
             String fileId,
             String progressName) {
-        requireContentFile(fileId);
-        FileProgressDB fileProgressDB = fileRepo.queryProgress(fileId, progressName);
+        return getProgress(requireContentFile(fileId), progressName);
+    }
+
+    public Progress getProgress(
+            FileDB file,
+            String progressName) {
+        FileProgressDB fileProgressDB = fileRepo.queryProgress(file.getFileId(), progressName);
         return fileProgressDB == null ? null : transferToProgress(fileProgressDB);
     }
 
@@ -583,23 +606,22 @@ public class FileService {
     }
 
     public String getPreviewUrl(String fileId, Long expires) {
-        requireContentFile(fileId);
-        FileDB file = fileRepo.queryFile(fileId);
+        return getPreviewUrl(requireContentFile(fileId), expires);
+    }
+
+    public String getPreviewUrl(FileDB file, Long expires) {
         String bucketName = file.getBucket();
         String keyName = file.getPath();
         return storageService.getPreviewUrl(bucketName, keyName, expires);
     }
 
     public InputStreamWithCharset getFileInputStream(String fileId) {
-        requireContentFile(fileId);
-        try {
-            // 获取文件信息
-            FileDB file = fileRepo.queryFile(fileId);
-            if(file == null) {
-                LOGGER.warn("file not found, file_id = {}", fileId);
-                return null;
-            }
+        return getFileInputStream(requireContentFile(fileId));
+    }
 
+    public InputStreamWithCharset getFileInputStream(FileDB file) {
+        String fileId = file.getFileId();
+        try {
             String bucketName = file.getBucket();
             String keyName = file.getPath();
 

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -472,10 +472,6 @@ public class FileService {
         FileDB fileDB = fileRepo.queryFile(ops.getFileId(), fileType);
         OpenAIFile finalOpenAIFile = buildOpenAIFileWithSource(fileDB);
 
-        if(NodeType.from(fileDB) == NodeType.RESOURCE) {
-            return finalOpenAIFile;
-        }
-
         FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
         message.setEvent(EventType.FILE_UPDATED);
         message.setScope(actionType.getValue());
@@ -503,8 +499,7 @@ public class FileService {
         String fileId = fileDB.getFileId();
         FileType fileType = FileType.fromFileId(fileId);
 
-        boolean resource = NodeType.from(fileDB) == NodeType.RESOURCE;
-        OpenAIFile fileToDelete = resource ? null : buildOpenAIFileWithSource(fileDB);
+        OpenAIFile fileToDelete = buildOpenAIFileWithSource(fileDB);
 
         // 只标记status字段，不删除文件，不删除数据库记录
         FileOps op = new FileOps();
@@ -517,18 +512,16 @@ public class FileService {
             }
 
             // 文件删除后的广播机制
-            if(!resource) {
-                FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
-                message.setEvent(EventType.FILE_DELETED);
-                message.setData(fileToDelete);
-                message.setMetadata(fileDB.getMetaData());
-                message.setUserId(BellaContextHelper.getOperatorUserId());
-                message.setUserName(BellaContextHelper.getOperatorUserName());
-                message.setAkCode(BellaContextHelper.getOperatorAkCode());
-                broadcastService.broadcast(message,
-                        () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
-                        () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
-            }
+            FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
+            message.setEvent(EventType.FILE_DELETED);
+            message.setData(fileToDelete);
+            message.setMetadata(fileDB.getMetaData());
+            message.setUserId(BellaContextHelper.getOperatorUserId());
+            message.setUserName(BellaContextHelper.getOperatorUserName());
+            message.setAkCode(BellaContextHelper.getOperatorAkCode());
+            broadcastService.broadcast(message,
+                    () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
+                    () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
         } catch (Exception e) {
             throw new IllegalStateException("Failed to update file status (indicating deletion), fileId: "
                     + fileId + ", status: " + FileStatus.DELETED, e);

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -27,6 +27,7 @@ import com.ke.bella.files.db.repo.Page;
 import com.ke.bella.files.db.tables.pojos.FileDB;
 import com.ke.bella.files.db.tables.pojos.FileProgressDB;
 import com.ke.bella.files.enums.FileType;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.BroadcastStatus;
 import com.ke.bella.files.protocol.EventType;
 import com.ke.bella.files.protocol.FileBroadcasting;
@@ -97,6 +98,7 @@ public class FileService {
     }
 
     private OpenAIFile transferToOpenAIFile(FileDB fileDB) {
+        NodeType nodeType = NodeType.from(fileDB);
         return OpenAIFile.builder()
                 .id(fileDB.getFileId())
                 .bytes(fileDB.getBytes())
@@ -104,7 +106,9 @@ public class FileService {
                         .toInstant(ZoneId.systemDefault().getRules().getOffset(fileDB.getCtime()))
                         .toEpochMilli())
                 .filename(fileDB.getFilename())
-                .isDir(fileDB.getIsDir() == 1)
+                .isDir(nodeType == NodeType.DIRECTORY)
+                .nodeType(nodeType.getValue())
+                .resourceId(fileDB.getResourceId())
                 .extension(fileDB.getExtension())
                 .mimeType(fileDB.getMimeType())
                 .type(fileDB.getType())
@@ -356,6 +360,8 @@ public class FileService {
         fileDB.setDescription(StringUtils.isNotEmpty(description) ? description : "");
         fileDB.setCities(citiesJson);
         fileDB.setTags(tagsJson);
+        fileDB.setNodeType(NodeType.FILE.getValue());
+        fileDB.setResourceId("");
         String shardingKey = fileRepo.addFile(fileDB, ancestorId, fileType);
         if(fileType.notUsersType()) {
             fileShardingCountUpdator.increase(shardingKey, fileType.getType());
@@ -431,12 +437,22 @@ public class FileService {
         return transferToOpenAIFile(fileDB);
     }
 
+    public OpenAIFile requireContentFile(String fileId) {
+        OpenAIFile file = getFile(fileId);
+        if(!NodeType.FILE.getValue().equals(file.getNodeType())) {
+            throw new IllegalArgumentException(String.format("node has no file content. file_id = %s, node_type = %s",
+                    fileId, file.getNodeType()));
+        }
+        return file;
+    }
+
     public FileDB getFile0(String fileId) {
         FileType fileType = FileType.fromFileId(fileId);
         return fileRepo.queryFile(fileId, fileType);
     }
 
     public String updateRealFile(String fileId, String filename, File file, String mimeType, String charset) {
+        requireContentFile(fileId);
         FileType fileType = FileType.fromFileId(fileId);
         FileDB fileDB = fileRepo.queryFile(fileId, fileType);
         return storageService.putObject(fileDB.getBucket(), fileDB.getPath(), mimeType, file, filename, charset);
@@ -444,6 +460,7 @@ public class FileService {
 
     public String updateRealFileFromStream(String fileId, String filename, java.io.InputStream inputStream, long contentLength, String mimeType,
             String charset) {
+        requireContentFile(fileId);
         FileDB fileDB = fileRepo.queryFile(fileId);
         return storageService.putObjectFromStream(fileDB.getBucket(), fileDB.getPath(), mimeType, inputStream, contentLength, filename, charset);
     }
@@ -454,6 +471,10 @@ public class FileService {
         fileRepo.updateFile(ops, increaseVersion);
         FileDB fileDB = fileRepo.queryFile(ops.getFileId(), fileType);
         OpenAIFile finalOpenAIFile = buildOpenAIFileWithSource(fileDB);
+
+        if(NodeType.from(fileDB) == NodeType.RESOURCE) {
+            return finalOpenAIFile;
+        }
 
         FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
         message.setEvent(EventType.FILE_UPDATED);
@@ -482,8 +503,8 @@ public class FileService {
         String fileId = fileDB.getFileId();
         FileType fileType = FileType.fromFileId(fileId);
 
-        // 构建广播数据
-        OpenAIFile fileToDelete = buildOpenAIFileWithSource(fileDB);
+        boolean resource = NodeType.from(fileDB) == NodeType.RESOURCE;
+        OpenAIFile fileToDelete = resource ? null : buildOpenAIFileWithSource(fileDB);
 
         // 只标记status字段，不删除文件，不删除数据库记录
         FileOps op = new FileOps();
@@ -496,16 +517,18 @@ public class FileService {
             }
 
             // 文件删除后的广播机制
-            FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
-            message.setEvent(EventType.FILE_DELETED);
-            message.setData(fileToDelete);
-            message.setMetadata(fileDB.getMetaData());
-            message.setUserId(BellaContextHelper.getOperatorUserId());
-            message.setUserName(BellaContextHelper.getOperatorUserName());
-            message.setAkCode(BellaContextHelper.getOperatorAkCode());
-            broadcastService.broadcast(message,
-                    () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
-                    () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
+            if(!resource) {
+                FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
+                message.setEvent(EventType.FILE_DELETED);
+                message.setData(fileToDelete);
+                message.setMetadata(fileDB.getMetaData());
+                message.setUserId(BellaContextHelper.getOperatorUserId());
+                message.setUserName(BellaContextHelper.getOperatorUserName());
+                message.setAkCode(BellaContextHelper.getOperatorAkCode());
+                broadcastService.broadcast(message,
+                        () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
+                        () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
+            }
         } catch (Exception e) {
             throw new IllegalStateException("Failed to update file status (indicating deletion), fileId: "
                     + fileId + ", status: " + FileStatus.DELETED, e);
@@ -519,6 +542,7 @@ public class FileService {
     public String getUrl(
             String fileId,
             long expires) {
+        requireContentFile(fileId);
         FileDB file = fileRepo.queryFile(fileId);
         return getUrl(file.getBucket(), file.getPath(), file.getPurpose(), expires);
     }
@@ -532,6 +556,7 @@ public class FileService {
             UpdateProgressRequestData data,
             String fileId,
             String progressName) {
+        requireContentFile(fileId);
         String status = data.getStatus();
         String message = data.getMessage();
         Integer percent = data.getPercent();
@@ -545,6 +570,7 @@ public class FileService {
     public Progress getProgress(
             String fileId,
             String progressName) {
+        requireContentFile(fileId);
         FileProgressDB fileProgressDB = fileRepo.queryProgress(fileId, progressName);
         return fileProgressDB == null ? null : transferToProgress(fileProgressDB);
     }
@@ -564,6 +590,7 @@ public class FileService {
     }
 
     public String getPreviewUrl(String fileId, Long expires) {
+        requireContentFile(fileId);
         FileDB file = fileRepo.queryFile(fileId);
         String bucketName = file.getBucket();
         String keyName = file.getPath();
@@ -571,6 +598,7 @@ public class FileService {
     }
 
     public InputStreamWithCharset getFileInputStream(String fileId) {
+        requireContentFile(fileId);
         try {
             // 获取文件信息
             FileDB file = fileRepo.queryFile(fileId);
@@ -611,6 +639,8 @@ public class FileService {
         fileDB.setMetaData("{}");
         fileDB.setAkCode(akCode);
         fileDB.setIsDir(1);
+        fileDB.setNodeType(NodeType.DIRECTORY.getValue());
+        fileDB.setResourceId("");
         fileDB.setDescription(description == null ? "" : description);
         fileDB.setCities("");
         fileDB.setTags("");
@@ -634,6 +664,39 @@ public class FileService {
         broadcastService.broadcast(message, () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
                 () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
         return openAIFile;
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public OpenAIFile createResource(String name, String resourceId, String ancestorId) {
+        String spaceCode = BellaContextHelper.getOperateSpaceCode();
+        String fileId = FILE_ID_GENERATOR.generateWithType(FileType.USER);
+
+        FileDB fileDB = new FileDB();
+        fileDB.setFileId(fileId);
+        fileDB.setFilename(name);
+        fileDB.setExtension("");
+        fileDB.setMimeType("");
+        fileDB.setType("");
+        fileDB.setBucket("");
+        fileDB.setPath("");
+        fileDB.setBytes(0L);
+        fileDB.setSpaceCode(spaceCode);
+        fileDB.setPurpose("");
+        fileDB.setMetaData("{}");
+        fileDB.setAkCode(BellaContextHelper.getOperatorAkCode());
+        fileDB.setIsDir(0);
+        fileDB.setDescription("");
+        fileDB.setCities("");
+        fileDB.setTags("");
+        fileDB.setNodeType(NodeType.RESOURCE.getValue());
+        fileDB.setResourceId(resourceId);
+
+        fileRepo.addFile(fileDB, ancestorId, FileType.USER);
+        FileDB created = fileRepo.queryFile(fileId, FileType.USER);
+        if(created == null) {
+            throw new FileNotFoundException(fileId);
+        }
+        return transferToOpenAIFile(created);
     }
 
     public List<OpenAIFile> findFiles(FileDB ancestor) {

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMkdirTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMkdirTest.java
@@ -23,6 +23,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
+import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.service.FileService;
 import com.ke.bella.files.service.lock.FileUniquenessLock;
@@ -44,6 +46,13 @@ public class FileControllerMkdirTest {
 
         ReflectionTestUtils.setField(fileController, "fileService", fileService);
         ReflectionTestUtils.setField(fileController, "fl", fileUniquenessLock);
+
+        FileDB ancestor = new FileDB();
+        ancestor.setFileId("anc-1");
+        ancestor.setSpaceCode("sp-a");
+        ancestor.setIsDir(1);
+        ancestor.setNodeType(NodeType.DIRECTORY.getValue());
+        when(fileService.getFile0("anc-1")).thenReturn(ancestor);
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE);

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMkdirTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMkdirTest.java
@@ -1,5 +1,7 @@
 package com.ke.bella.files.api;
 
+import static com.ke.bella.files.api.FileControllerTestFixture.stubDirectory;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,8 +25,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
-import com.ke.bella.files.db.tables.pojos.FileDB;
-import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.service.FileService;
 import com.ke.bella.files.service.lock.FileUniquenessLock;
@@ -47,12 +47,7 @@ public class FileControllerMkdirTest {
         ReflectionTestUtils.setField(fileController, "fileService", fileService);
         ReflectionTestUtils.setField(fileController, "fl", fileUniquenessLock);
 
-        FileDB ancestor = new FileDB();
-        ancestor.setFileId("anc-1");
-        ancestor.setSpaceCode("sp-a");
-        ancestor.setIsDir(1);
-        ancestor.setNodeType(NodeType.DIRECTORY.getValue());
-        when(fileService.getFile0("anc-1")).thenReturn(ancestor);
+        stubDirectory(fileService, "anc-1", "sp-a");
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE);

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
 import com.ke.bella.files.db.repo.Page;
+import com.ke.bella.files.db.tables.pojos.FileDB;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.files.service.FileService;
@@ -92,6 +93,11 @@ public class FileControllerPageFilesTest {
 
         when(fileService.pageFiles(any(PageFileOps.class)))
                 .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(total).list(data));
+        FileDB ancestor = new FileDB();
+        ancestor.setFileId("dir-1");
+        ancestor.setIsDir(1);
+        ancestor.setNodeType("file");
+        when(fileService.getFile0("dir-1")).thenReturn(ancestor);
 
         // When & Then
         mockMvc.perform(post("/v1/files/page")

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
 import com.ke.bella.files.db.repo.Page;
 import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.files.service.FileService;
@@ -42,6 +43,12 @@ public class FileControllerPageFilesTest {
 
         ReflectionTestUtils.setField(fileController, "fileService", fileService);
         ReflectionTestUtils.setField(fileController, "fl", fileUniquenessLock);
+
+        FileDB ancestor = new FileDB();
+        ancestor.setFileId("dir-1");
+        ancestor.setIsDir(1);
+        ancestor.setNodeType(NodeType.DIRECTORY.getValue());
+        when(fileService.getFile0("dir-1")).thenReturn(ancestor);
 
         mockMvc = MockMvcBuilders
                 .standaloneSetup(fileController)
@@ -291,7 +298,7 @@ public class FileControllerPageFilesTest {
                         "  \"order\": \"desc\"\n" +
                         "}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.message").value("type must be 'dir' or 'file', but got: "));
+                .andExpect(jsonPath("$.error.message").value("type must be 'dir', 'file' or 'resource', but got: "));
     }
 
     @Test
@@ -308,7 +315,7 @@ public class FileControllerPageFilesTest {
                         "  \"order\": \"desc\"\n" +
                         "}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.message").value("type must be 'dir' or 'file', but got: folder"));
+                .andExpect(jsonPath("$.error.message").value("type must be 'dir', 'file' or 'resource', but got: folder"));
     }
 
     @Test

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
@@ -1,5 +1,7 @@
 package com.ke.bella.files.api;
 
+import static com.ke.bella.files.api.FileControllerTestFixture.stubDirectory;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -23,8 +25,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
 import com.ke.bella.files.db.repo.Page;
-import com.ke.bella.files.db.tables.pojos.FileDB;
-import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.files.service.FileService;
@@ -44,11 +44,7 @@ public class FileControllerPageFilesTest {
         ReflectionTestUtils.setField(fileController, "fileService", fileService);
         ReflectionTestUtils.setField(fileController, "fl", fileUniquenessLock);
 
-        FileDB ancestor = new FileDB();
-        ancestor.setFileId("dir-1");
-        ancestor.setIsDir(1);
-        ancestor.setNodeType(NodeType.DIRECTORY.getValue());
-        when(fileService.getFile0("dir-1")).thenReturn(ancestor);
+        stubDirectory(fileService, "dir-1");
 
         mockMvc = MockMvcBuilders
                 .standaloneSetup(fileController)
@@ -100,12 +96,6 @@ public class FileControllerPageFilesTest {
 
         when(fileService.pageFiles(any(PageFileOps.class)))
                 .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(total).list(data));
-        FileDB ancestor = new FileDB();
-        ancestor.setFileId("dir-1");
-        ancestor.setIsDir(1);
-        ancestor.setNodeType("file");
-        when(fileService.getFile0("dir-1")).thenReturn(ancestor);
-
         // When & Then
         mockMvc.perform(post("/v1/files/page")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
 import com.ke.bella.files.db.repo.Page;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.files.service.FileService;
@@ -247,15 +248,19 @@ public class FileControllerPageFilesTest {
 
     @Test
     public void pageFiles_MissingType_Success() throws Exception {
-        // Given: 不传 type 参数，应该成功并返回所有 file 和 dir
+        // Given: 不传 type 参数，应该返回目录、文件和资源节点
         int page = 1;
         int pageSize = 10;
         List<OpenAIFile> data = Arrays.asList(
-                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true).build(),
-                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false).build());
+                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true)
+                        .nodeType(NodeType.DIRECTORY.getValue()).build(),
+                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false)
+                        .nodeType(NodeType.FILE.getValue()).build(),
+                OpenAIFile.builder().id("resource-1").filename("dataset").isDir(false)
+                        .nodeType(NodeType.RESOURCE.getValue()).resourceId("dataset:1").build());
 
         when(fileService.pageFiles(any(PageFileOps.class)))
-                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(3).list(data));
 
         // When & Then
         mockMvc.perform(post("/v1/files/page")
@@ -267,11 +272,15 @@ public class FileControllerPageFilesTest {
                         "  \"order\": \"desc\"\n" +
                         "}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].id").value("dir-1"))
-                .andExpect(jsonPath("$.data[1].id").value("file-1"));
+                .andExpect(jsonPath("$.total").value(3))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].node_type").value(NodeType.DIRECTORY.getValue()))
+                .andExpect(jsonPath("$.data[1].node_type").value(NodeType.FILE.getValue()))
+                .andExpect(jsonPath("$.data[2].node_type").value(NodeType.RESOURCE.getValue()))
+                .andExpect(jsonPath("$.data[2].resource_id").value("dataset:1"));
 
         // 验证 type 参数为 null
-        verify(fileService).pageFiles(argThat(ops -> ops.getType() == null));
+        verify(fileService).pageFiles(argThat(ops -> ops.getType() == null && ops.getPurpose() == null));
     }
 
     @Test
@@ -314,8 +323,10 @@ public class FileControllerPageFilesTest {
         int page = 1;
         int pageSize = 10;
         List<OpenAIFile> data = Arrays.asList(
-                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true).build(),
-                OpenAIFile.builder().id("dir-2").filename("folder2").isDir(true).build());
+                OpenAIFile.builder().id("dir-1").filename("folder1").isDir(true)
+                        .nodeType(NodeType.DIRECTORY.getValue()).build(),
+                OpenAIFile.builder().id("dir-2").filename("folder2").isDir(true)
+                        .nodeType(NodeType.DIRECTORY.getValue()).build());
 
         when(fileService.pageFiles(any(PageFileOps.class)))
                 .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
@@ -330,7 +341,11 @@ public class FileControllerPageFilesTest {
                         "  \"type\": \"dir\",\n" +
                         "  \"order\": \"desc\"\n" +
                         "}"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].node_type").value(NodeType.DIRECTORY.getValue()))
+                .andExpect(jsonPath("$.data[1].node_type").value(NodeType.DIRECTORY.getValue()));
 
         // 验证 type 参数为 "dir"
         verify(fileService).pageFiles(argThat(ops -> "dir".equals(ops.getType())));
@@ -342,8 +357,10 @@ public class FileControllerPageFilesTest {
         int page = 1;
         int pageSize = 10;
         List<OpenAIFile> data = Arrays.asList(
-                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false).purpose("assistants").build(),
-                OpenAIFile.builder().id("file-2").filename("img.jpg").isDir(false).purpose("vision").build());
+                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false)
+                        .nodeType(NodeType.FILE.getValue()).purpose("assistants").build(),
+                OpenAIFile.builder().id("file-2").filename("img.jpg").isDir(false)
+                        .nodeType(NodeType.FILE.getValue()).purpose("vision").build());
 
         when(fileService.pageFiles(any(PageFileOps.class)))
                 .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
@@ -359,42 +376,46 @@ public class FileControllerPageFilesTest {
                         "  \"order\": \"desc\"\n" +
                         "}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].id").value("file-1"))
-                .andExpect(jsonPath("$.data[1].id").value("file-2"));
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].node_type").value(NodeType.FILE.getValue()))
+                .andExpect(jsonPath("$.data[1].node_type").value(NodeType.FILE.getValue()));
 
         // 验证 type 为 file 且 purpose 为 null
         verify(fileService).pageFiles(argThat(ops -> "file".equals(ops.getType()) && ops.getPurpose() == null));
     }
 
     @Test
-    public void pageFiles_NoTypeNoPurpose_Success() throws Exception {
-        // Given: 既不传 type 也不传 purpose，应该返回所有文件和目录
+    public void pageFiles_TypeResource_Success() throws Exception {
         int page = 1;
         int pageSize = 10;
         List<OpenAIFile> data = Arrays.asList(
-                OpenAIFile.builder().id("dir-1").filename("folder").isDir(true).build(),
-                OpenAIFile.builder().id("file-1").filename("doc.txt").isDir(false).purpose("assistants").build(),
-                OpenAIFile.builder().id("file-2").filename("img.jpg").isDir(false).purpose("vision").build());
+                OpenAIFile.builder().id("resource-1").filename("dataset-1").isDir(false)
+                        .nodeType(NodeType.RESOURCE.getValue()).resourceId("dataset:1").build(),
+                OpenAIFile.builder().id("resource-2").filename("workflow-2").isDir(false)
+                        .nodeType(NodeType.RESOURCE.getValue()).resourceId("workflow:2").build());
 
         when(fileService.pageFiles(any(PageFileOps.class)))
-                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(3).list(data));
+                .thenReturn(Page.<OpenAIFile>from(page, pageSize).total(2).list(data));
 
-        // When & Then
         mockMvc.perform(post("/v1/files/page")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\n" +
                         "  \"space_code\": \"space-1\",\n" +
                         "  \"page\": 1,\n" +
                         "  \"page_size\": 10,\n" +
+                        "  \"type\": \"resource\",\n" +
                         "  \"order\": \"desc\"\n" +
                         "}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].id").value("dir-1"))
-                .andExpect(jsonPath("$.data[1].id").value("file-1"))
-                .andExpect(jsonPath("$.data[2].id").value("file-2"));
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].node_type").value(NodeType.RESOURCE.getValue()))
+                .andExpect(jsonPath("$.data[0].resource_id").value("dataset:1"))
+                .andExpect(jsonPath("$.data[1].node_type").value(NodeType.RESOURCE.getValue()))
+                .andExpect(jsonPath("$.data[1].resource_id").value("workflow:2"));
 
-        // 验证 type 和 purpose 都为 null
-        verify(fileService).pageFiles(argThat(ops -> ops.getType() == null && ops.getPurpose() == null));
+        verify(fileService).pageFiles(argThat(ops -> "resource".equals(ops.getType()) && ops.getPurpose() == null));
     }
 
     // ========== 新增测试：purpose 和 type 的组合场景 ==========

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerPageFilesTest.java
@@ -47,10 +47,13 @@ public class FileControllerPageFilesTest {
 
         stubDirectory(fileService, "dir-1");
 
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE);
+
         mockMvc = MockMvcBuilders
                 .standaloneSetup(fileController)
                 .setControllerAdvice(new FileApiResponseAdvice())
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(new ObjectMapper()))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .build();
     }
 

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerResourceTest.java
@@ -65,22 +65,24 @@ public class FileControllerResourceTest {
         when(fileService.getFile0("file-parent-1-d")).thenReturn(ancestor);
         when(fileUniquenessLock.executeWithLock(eq("sp-a"), eq("file-parent-1-d"), eq("Sales dataset"), anyLong(), any()))
                 .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
-        when(fileService.createResource("Sales dataset", "dataset:12345", "file-parent-1-d"))
+        when(fileService.createResource("Sales dataset", "dataset:12345", "file-parent-1-d", "assistants"))
                 .thenReturn(OpenAIFile.builder()
                         .id("file-resource-1")
                         .filename("Sales dataset")
                         .nodeType(NodeType.RESOURCE.getValue())
                         .resourceId("dataset:12345")
+                        .purpose("assistants")
                         .isDir(false)
                         .bytes(0L)
                         .build());
 
         mockMvc.perform(post("/v1/files/resources")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"Sales dataset\",\"resource_id\":\"dataset:12345\",\"ancestor_id\":\"file-parent-1-d\"}"))
+                .content("{\"name\":\"Sales dataset\",\"resource_id\":\"dataset:12345\",\"ancestor_id\":\"file-parent-1-d\",\"purpose\":\"assistants\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.node_type").value("resource"))
                 .andExpect(jsonPath("$.resource_id").value("dataset:12345"))
+                .andExpect(jsonPath("$.purpose").value("assistants"))
                 .andExpect(jsonPath("$.is_dir").value(false));
     }
 
@@ -91,7 +93,17 @@ public class FileControllerResourceTest {
                 .content("{\"name\":\"Sales dataset\",\"resource_id\":\"dataset\"}"))
                 .andExpect(status().isBadRequest());
 
-        verify(fileService, never()).createResource(any(), any(), any());
+        verify(fileService, never()).createResource(any(), any(), any(), any());
+    }
+
+    @Test
+    public void rejectUnsupportedPurpose() throws Exception {
+        mockMvc.perform(post("/v1/files/resources")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Sales dataset\",\"resource_id\":\"dataset:12345\",\"purpose\":\"unsupported\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(fileService, never()).createResource(any(), any(), any(), any());
     }
 
     @Test
@@ -108,7 +120,7 @@ public class FileControllerResourceTest {
                 .content("{\"name\":\"Child\",\"resource_id\":\"dataset:2\",\"ancestor_id\":\"file-resource-1\"}"))
                 .andExpect(status().isBadRequest());
 
-        verify(fileService, never()).createResource(any(), any(), any());
+        verify(fileService, never()).createResource(any(), any(), any(), any());
     }
 
     @Test

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerResourceTest.java
@@ -1,0 +1,124 @@
+package com.ke.bella.files.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
+import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.NodeType;
+import com.ke.bella.files.protocol.OpenAIFile;
+import com.ke.bella.files.service.FileService;
+import com.ke.bella.files.service.lock.FileUniquenessLock;
+import com.ke.bella.openapi.BellaContext;
+import com.ke.bella.openapi.Operator;
+
+public class FileControllerResourceTest {
+    private MockMvc mockMvc;
+    private FileService fileService;
+    private FileUniquenessLock fileUniquenessLock;
+
+    @Before
+    public void setup() {
+        fileService = Mockito.mock(FileService.class);
+        fileUniquenessLock = Mockito.mock(FileUniquenessLock.class);
+        FileController fileController = new FileController();
+        ReflectionTestUtils.setField(fileController, "fileService", fileService);
+        ReflectionTestUtils.setField(fileController, "fl", fileUniquenessLock);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE);
+        mockMvc = MockMvcBuilders.standaloneSetup(fileController)
+                .setControllerAdvice(new FileApiResponseAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+    }
+
+    @Test
+    public void createResourceInDirectory() throws Exception {
+        FileDB ancestor = new FileDB();
+        ancestor.setFileId("file-parent-1-d");
+        ancestor.setSpaceCode("sp-a");
+        ancestor.setIsDir(1);
+        ancestor.setNodeType(NodeType.DIRECTORY.getValue());
+        when(fileService.getFile0("file-parent-1-d")).thenReturn(ancestor);
+        when(fileUniquenessLock.executeWithLock(eq("sp-a"), eq("file-parent-1-d"), eq("Sales dataset"), anyLong(), any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+        when(fileService.createResource("Sales dataset", "dataset:12345", "file-parent-1-d"))
+                .thenReturn(OpenAIFile.builder()
+                        .id("file-resource-1")
+                        .filename("Sales dataset")
+                        .nodeType(NodeType.RESOURCE.getValue())
+                        .resourceId("dataset:12345")
+                        .isDir(false)
+                        .bytes(0L)
+                        .build());
+
+        mockMvc.perform(post("/v1/files/resources")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Sales dataset\",\"resource_id\":\"dataset:12345\",\"ancestor_id\":\"file-parent-1-d\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_type").value("resource"))
+                .andExpect(jsonPath("$.resource_id").value("dataset:12345"))
+                .andExpect(jsonPath("$.is_dir").value(false));
+    }
+
+    @Test
+    public void rejectInvalidResourceId() throws Exception {
+        mockMvc.perform(post("/v1/files/resources")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Sales dataset\",\"resource_id\":\"dataset\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(fileService, never()).createResource(any(), any(), any());
+    }
+
+    @Test
+    public void rejectResourceAsAncestor() throws Exception {
+        FileDB ancestor = new FileDB();
+        ancestor.setFileId("file-resource-1");
+        ancestor.setSpaceCode("sp-a");
+        ancestor.setIsDir(0);
+        ancestor.setNodeType(NodeType.RESOURCE.getValue());
+        when(fileService.getFile0("file-resource-1")).thenReturn(ancestor);
+
+        mockMvc.perform(post("/v1/files/resources")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Child\",\"resource_id\":\"dataset:2\",\"ancestor_id\":\"file-resource-1\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(fileService, never()).createResource(any(), any(), any());
+    }
+
+    @Test
+    public void contentUrlRejectsResourceBeforeStorageLookup() throws Exception {
+        when(fileService.requireContentFile("file-resource-1"))
+                .thenThrow(new IllegalArgumentException("node has no file content"));
+
+        mockMvc.perform(get("/v1/files/file-resource-1/url"))
+                .andExpect(status().isBadRequest());
+
+        verify(fileService, never()).getUrl(eq("file-resource-1"), anyLong());
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerTestFixture.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerTestFixture.java
@@ -1,0 +1,26 @@
+package com.ke.bella.files.api;
+
+import static org.mockito.Mockito.when;
+
+import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.NodeType;
+import com.ke.bella.files.service.FileService;
+
+final class FileControllerTestFixture {
+
+    private FileControllerTestFixture() {
+    }
+
+    static void stubDirectory(FileService fileService, String fileId) {
+        stubDirectory(fileService, fileId, null);
+    }
+
+    static void stubDirectory(FileService fileService, String fileId, String spaceCode) {
+        FileDB directory = new FileDB();
+        directory.setFileId(fileId);
+        directory.setSpaceCode(spaceCode);
+        directory.setIsDir(1);
+        directory.setNodeType(NodeType.DIRECTORY.getValue());
+        when(fileService.getFile0(fileId)).thenReturn(directory);
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -126,6 +126,28 @@ public class FileRepoMoveTest {
     }
 
     @Test
+    public void pageTypeFiltersHonorIsDirDuringRollingDeployment() {
+        Page<FileDB> directories = fileRepo.pageFiles(PageFileOps.builder()
+                .ancestorId(SOURCE)
+                .type("dir")
+                .page(1)
+                .pageSize(10)
+                .order("asc")
+                .build());
+        assertEquals(1, directories.getTotal());
+        assertEquals(CHILD, directories.getData().get(0).getFileId());
+
+        Page<FileDB> files = fileRepo.pageFiles(PageFileOps.builder()
+                .ancestorId(SOURCE)
+                .type("file")
+                .page(1)
+                .pageSize(10)
+                .order("asc")
+                .build());
+        assertEquals(0, files.getTotal());
+    }
+
+    @Test
     public void moveLeafUsesSameSubtreeAlgorithm() {
         fileRepo.moveFileClosures(LEAF, TARGET);
 

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoMoveTest.java
@@ -9,9 +9,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jooq.DSLContext;
@@ -25,6 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.openapi.BellaContext;
 import com.ke.bella.openapi.Operator;
@@ -36,6 +39,9 @@ public class FileRepoMoveTest {
     private static final String LEAF = "file-leaf-0";
     private static final String NEW_ROOT = "file-new-root-0-d";
     private static final String TARGET = "file-target-0-d";
+    private static final String PAGE_DIRECTORY = "file-page-dir-0-d";
+    private static final String PAGE_FILE = "file-page-file-0";
+    private static final String PAGE_RESOURCE = "file-page-resource-0";
 
     private static Connection connection;
     private static DSLContext dsl;
@@ -148,6 +154,27 @@ public class FileRepoMoveTest {
     }
 
     @Test
+    public void pageTypeFiltersReturnMixedNodesAndMatchingTotals() {
+        insertPageNode(PAGE_DIRECTORY, "page-directory", 1, NodeType.DIRECTORY, "");
+        insertPageNode(PAGE_FILE, "page-file.txt", 0, NodeType.FILE, "");
+        insertPageNode(PAGE_RESOURCE, "page-resource", 0, NodeType.RESOURCE, "dataset:1");
+
+        Page<FileDB> mixed = pageTarget(null);
+        assertEquals(3, mixed.getTotal());
+        assertEquals(3, mixed.getData().size());
+        Set<String> mixedIds = mixed.getData().stream().map(FileDB::getFileId).collect(Collectors.toSet());
+        assertEquals(new HashSet<>(Arrays.asList(PAGE_DIRECTORY, PAGE_FILE, PAGE_RESOURCE)), mixedIds);
+        Set<String> mixedNodeTypes = mixed.getData().stream().map(FileDB::getNodeType).collect(Collectors.toSet());
+        assertEquals(new HashSet<>(Arrays.asList(NodeType.DIRECTORY.getValue(), NodeType.FILE.getValue(),
+                NodeType.RESOURCE.getValue())), mixedNodeTypes);
+
+        assertSinglePageNode("dir", PAGE_DIRECTORY, NodeType.DIRECTORY);
+        assertSinglePageNode("file", PAGE_FILE, NodeType.FILE);
+        Page<FileDB> resources = assertSinglePageNode("resource", PAGE_RESOURCE, NodeType.RESOURCE);
+        assertEquals("dataset:1", resources.getData().get(0).getResourceId());
+    }
+
+    @Test
     public void moveLeafUsesSameSubtreeAlgorithm() {
         fileRepo.moveFileClosures(LEAF, TARGET);
 
@@ -255,6 +282,32 @@ public class FileRepoMoveTest {
     private void insertFile(String fileId, String filename, boolean directory) {
         dsl.execute("insert into file_0 (file_id, filename, is_dir, space_code, meta_data) values (?, ?, ?, ?, ?)",
                 fileId, filename, directory ? 1 : 0, "sp-0", "{}");
+    }
+
+    private void insertPageNode(String fileId, String filename, int isDir, NodeType nodeType, String resourceId) {
+        dsl.execute("insert into file_0 (file_id, filename, is_dir, node_type, resource_id, space_code, meta_data) "
+                        + "values (?, ?, ?, ?, ?, ?, ?)",
+                fileId, filename, isDir, nodeType.getValue(), resourceId, "sp-0", "{}");
+        insertClosure(TARGET, fileId, 1L, -1L);
+    }
+
+    private Page<FileDB> pageTarget(String type) {
+        return fileRepo.pageFiles(PageFileOps.builder()
+                .ancestorId(TARGET)
+                .type(type)
+                .page(1)
+                .pageSize(10)
+                .order("asc")
+                .build());
+    }
+
+    private Page<FileDB> assertSinglePageNode(String type, String expectedFileId, NodeType expectedNodeType) {
+        Page<FileDB> page = pageTarget(type);
+        assertEquals(1, page.getTotal());
+        assertEquals(1, page.getData().size());
+        assertEquals(expectedFileId, page.getData().get(0).getFileId());
+        assertEquals(expectedNodeType.getValue(), page.getData().get(0).getNodeType());
+        return page;
     }
 
     private void insertClosure(String ancestorId, String descendantId, long depth, long rootDepth) {

--- a/api/src/test/java/com/ke/bella/files/enums/NodeTypeTest.java
+++ b/api/src/test/java/com/ke/bella/files/enums/NodeTypeTest.java
@@ -1,0 +1,28 @@
+package com.ke.bella.files.enums;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ke.bella.files.db.tables.pojos.FileDB;
+
+public class NodeTypeTest {
+
+    @Test
+    public void directoryFlagWinsOverDefaultNodeTypeDuringRollingDeployment() {
+        FileDB file = new FileDB();
+        file.setIsDir(1);
+        file.setNodeType(NodeType.FILE.getValue());
+
+        assertEquals(NodeType.DIRECTORY, NodeType.from(file));
+    }
+
+    @Test
+    public void resourceRemainsResourceForLeafNodes() {
+        FileDB file = new FileDB();
+        file.setIsDir(0);
+        file.setNodeType(NodeType.RESOURCE.getValue());
+
+        assertEquals(NodeType.RESOURCE, NodeType.from(file));
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
@@ -94,6 +94,7 @@ public class FileServiceResourceTest {
                 () -> fileService.getUrl("file-resource-1"));
 
         assertTrue(error.getMessage().contains("no file content"));
+        verify(fileRepo).queryFile("file-resource-1", FileType.USER);
         verifyNoInteractions(storageService);
     }
 

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
@@ -27,7 +27,10 @@ import com.ke.bella.files.enums.FileType;
 import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.EventType;
 import com.ke.bella.files.protocol.FileBroadcasting;
+import com.ke.bella.files.protocol.FileOps;
+import com.ke.bella.files.protocol.FileStatus;
 import com.ke.bella.files.protocol.OpenAIFile;
+import com.ke.bella.files.protocol.Scope;
 import com.ke.bella.files.service.broadcast.BroadcastService;
 import com.ke.bella.files.service.storage.StorageService;
 import com.ke.bella.openapi.BellaContext;
@@ -83,15 +86,7 @@ public class FileServiceResourceTest {
 
     @Test
     public void resourceCannotResolveContentUrl() {
-        FileDB resource = new FileDB();
-        resource.setFileId("file-resource-1");
-        resource.setFilename("Sales dataset");
-        resource.setNodeType(NodeType.RESOURCE.getValue());
-        resource.setResourceId("dataset:12345");
-        resource.setIsDir(0);
-        resource.setBytes(0L);
-        resource.setCtime(LocalDateTime.now());
-        resource.setMtime(LocalDateTime.now());
+        FileDB resource = resourceFile();
         when(fileRepo.queryFile("file-resource-1", FileType.USER)).thenReturn(resource);
 
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
@@ -99,5 +94,56 @@ public class FileServiceResourceTest {
 
         assertTrue(error.getMessage().contains("no file content"));
         verifyNoInteractions(storageService);
+    }
+
+    @Test
+    public void updateResourceBroadcastsUpdatedEvent() {
+        FileDB resource = resourceFile();
+        when(fileRepo.queryFile("file-resource-1", FileType.USER)).thenReturn(resource);
+
+        OpenAIFile updated = fileService.updateFile(FileOps.builder()
+                .fileId("file-resource-1")
+                .filename("Renamed dataset")
+                .build(), false, Scope.FILENAME);
+
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_UPDATED.getValue(), messageCaptor.getValue().getEvent());
+        assertEquals(Scope.FILENAME.getValue(), messageCaptor.getValue().getScope());
+        assertEquals(updated, messageCaptor.getValue().getData());
+        verifyNoInteractions(storageService);
+    }
+
+    @Test
+    public void deleteResourceBroadcastsDeletedEvent() {
+        FileDB resource = resourceFile();
+
+        fileService.delete(resource);
+
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_DELETED.getValue(), messageCaptor.getValue().getEvent());
+        OpenAIFile deleted = (OpenAIFile) messageCaptor.getValue().getData();
+        assertEquals(NodeType.RESOURCE.getValue(), deleted.getNodeType());
+        assertEquals("dataset:12345", deleted.getResourceId());
+        verify(fileRepo).updateFile(org.mockito.ArgumentMatchers.argThat(op -> op.getStatus() == FileStatus.DELETED),
+                org.mockito.ArgumentMatchers.eq(false));
+        verify(fileRepo).deleteFileClosure("file-resource-1", FileType.USER);
+        verifyNoInteractions(storageService);
+    }
+
+    private FileDB resourceFile() {
+        FileDB resource = new FileDB();
+        resource.setFileId("file-resource-1");
+        resource.setFilename("Sales dataset");
+        resource.setNodeType(NodeType.RESOURCE.getValue());
+        resource.setResourceId("dataset:12345");
+        resource.setIsDir(0);
+        resource.setBytes(0L);
+        resource.setPurpose("");
+        resource.setMetaData("{}");
+        resource.setCtime(LocalDateTime.now());
+        resource.setMtime(LocalDateTime.now());
+        return resource;
     }
 }

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
@@ -1,0 +1,95 @@
+package com.ke.bella.files.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ke.bella.files.FileShardingCountUpdator;
+import com.ke.bella.files.configuration.BucketConfig;
+import com.ke.bella.files.db.repo.FileRepo;
+import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.FileType;
+import com.ke.bella.files.enums.NodeType;
+import com.ke.bella.files.protocol.OpenAIFile;
+import com.ke.bella.files.service.broadcast.BroadcastService;
+import com.ke.bella.files.service.storage.StorageService;
+import com.ke.bella.openapi.BellaContext;
+import com.ke.bella.openapi.Operator;
+
+public class FileServiceResourceTest {
+    private FileService fileService;
+    private FileRepo fileRepo;
+    private StorageService storageService;
+    private BroadcastService broadcastService;
+
+    @Before
+    public void setup() {
+        fileService = new FileService();
+        fileRepo = Mockito.mock(FileRepo.class);
+        storageService = Mockito.mock(StorageService.class);
+        broadcastService = Mockito.mock(BroadcastService.class);
+        ReflectionTestUtils.setField(fileService, "fileRepo", fileRepo);
+        ReflectionTestUtils.setField(fileService, "storageService", storageService);
+        ReflectionTestUtils.setField(fileService, "bucketConfig", Mockito.mock(BucketConfig.class));
+        ReflectionTestUtils.setField(fileService, "broadcastService", broadcastService);
+        ReflectionTestUtils.setField(fileService, "fileShardingCountUpdator", Mockito.mock(FileShardingCountUpdator.class));
+        ReflectionTestUtils.setField(fileService, "self", fileService);
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+    }
+
+    @Test
+    public void createResourceOnlyWritesDatabaseNode() {
+        AtomicReference<FileDB> inserted = new AtomicReference<>();
+        when(fileRepo.addFile(any(FileDB.class), anyString(), any(FileType.class))).thenAnswer(invocation -> {
+            FileDB file = invocation.getArgument(0);
+            file.setCtime(LocalDateTime.now());
+            file.setMtime(LocalDateTime.now());
+            inserted.set(file);
+            return "1";
+        });
+        when(fileRepo.queryFile(anyString(), any(FileType.class))).thenAnswer(invocation -> inserted.get());
+
+        OpenAIFile resource = fileService.createResource("Sales dataset", "dataset:12345", "file-parent-1-d");
+
+        assertEquals(NodeType.RESOURCE.getValue(), resource.getNodeType());
+        assertEquals("dataset:12345", resource.getResourceId());
+        assertFalse(resource.getIsDir());
+        assertEquals(Long.valueOf(0L), resource.getBytes());
+        verify(fileRepo).addFile(any(FileDB.class), org.mockito.ArgumentMatchers.eq("file-parent-1-d"),
+                org.mockito.ArgumentMatchers.eq(FileType.USER));
+        verifyNoInteractions(storageService, broadcastService);
+    }
+
+    @Test
+    public void resourceCannotResolveContentUrl() {
+        FileDB resource = new FileDB();
+        resource.setFileId("file-resource-1");
+        resource.setFilename("Sales dataset");
+        resource.setNodeType(NodeType.RESOURCE.getValue());
+        resource.setResourceId("dataset:12345");
+        resource.setIsDir(0);
+        resource.setBytes(0L);
+        resource.setCtime(LocalDateTime.now());
+        resource.setMtime(LocalDateTime.now());
+        when(fileRepo.queryFile("file-resource-1", FileType.USER)).thenReturn(resource);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> fileService.getUrl("file-resource-1"));
+
+        assertEquals("node has no file content. file_id = file-resource-1, node_type = resource", error.getMessage());
+        verifyNoInteractions(storageService);
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
@@ -3,6 +3,7 @@ package com.ke.bella.files.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -23,6 +25,8 @@ import com.ke.bella.files.db.repo.FileRepo;
 import com.ke.bella.files.db.tables.pojos.FileDB;
 import com.ke.bella.files.enums.FileType;
 import com.ke.bella.files.enums.NodeType;
+import com.ke.bella.files.protocol.EventType;
+import com.ke.bella.files.protocol.FileBroadcasting;
 import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.service.broadcast.BroadcastService;
 import com.ke.bella.files.service.storage.StorageService;
@@ -51,7 +55,7 @@ public class FileServiceResourceTest {
     }
 
     @Test
-    public void createResourceOnlyWritesDatabaseNode() {
+    public void createResourceWritesDatabaseNodeAndBroadcastsCreatedEvent() {
         AtomicReference<FileDB> inserted = new AtomicReference<>();
         when(fileRepo.addFile(any(FileDB.class), anyString(), any(FileType.class))).thenAnswer(invocation -> {
             FileDB file = invocation.getArgument(0);
@@ -70,7 +74,11 @@ public class FileServiceResourceTest {
         assertEquals(Long.valueOf(0L), resource.getBytes());
         verify(fileRepo).addFile(any(FileDB.class), org.mockito.ArgumentMatchers.eq("file-parent-1-d"),
                 org.mockito.ArgumentMatchers.eq(FileType.USER));
-        verifyNoInteractions(storageService, broadcastService);
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_CREATED.getValue(), messageCaptor.getValue().getEvent());
+        assertEquals(resource, messageCaptor.getValue().getData());
+        verifyNoInteractions(storageService);
     }
 
     @Test
@@ -89,7 +97,7 @@ public class FileServiceResourceTest {
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
                 () -> fileService.getUrl("file-resource-1"));
 
-        assertEquals("node has no file content. file_id = file-resource-1, node_type = resource", error.getMessage());
+        assertTrue(error.getMessage().contains("no file content"));
         verifyNoInteractions(storageService);
     }
 }

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
@@ -69,10 +69,11 @@ public class FileServiceResourceTest {
         });
         when(fileRepo.queryFile(anyString(), any(FileType.class))).thenAnswer(invocation -> inserted.get());
 
-        OpenAIFile resource = fileService.createResource("Sales dataset", "dataset:12345", "file-parent-1-d");
+        OpenAIFile resource = fileService.createResource("Sales dataset", "dataset:12345", "file-parent-1-d", "assistants");
 
         assertEquals(NodeType.RESOURCE.getValue(), resource.getNodeType());
         assertEquals("dataset:12345", resource.getResourceId());
+        assertEquals("assistants", resource.getPurpose());
         assertFalse(resource.getIsDir());
         assertEquals(Long.valueOf(0L), resource.getBytes());
         verify(fileRepo).addFile(any(FileDB.class), org.mockito.ArgumentMatchers.eq("file-parent-1-d"),

--- a/web/src/app/admin/files/_components/columns.tsx
+++ b/web/src/app/admin/files/_components/columns.tsx
@@ -10,12 +10,15 @@ import {
   FileIcon,
   FileJsonIcon,
   FolderIcon,
+  Boxes,
+  Copy,
   Pencil,
   MoreHorizontal,
   Move,
   Trash2,
   Upload,
 } from "lucide-react";
+import { toast } from "sonner";
 import {
   RiFileExcel2Line,
   RiFilePdf2Line,
@@ -69,7 +72,8 @@ const FilenameCell = ({
   onReUpload: (file: KnowledgeFile, newFile: File) => Promise<boolean>;
   siblingFiles?: KnowledgeFile[];
 }) => {
-  const isDir = file.is_dir;
+  const isDir = file.node_type === "directory";
+  const isResource = file.node_type === "resource";
   const isImage = file.mime_type.startsWith("image/");
   const extension = file.mime_type.split("/")[1];
   const props = {
@@ -78,6 +82,9 @@ const FilenameCell = ({
   let icon = <FileIcon {...props} />;
   if (isDir) {
     icon = <FolderIcon {...props} />;
+  }
+  if (isResource) {
+    icon = <Boxes {...props} />;
   }
   if (extension === "pdf") {
     icon = <RiFilePdf2Line {...props} />;
@@ -121,11 +128,13 @@ const FilenameCell = ({
     if (!isEditing || !inputValue.trim() || inputValue === file.filename) {
       return false;
     }
-    return siblingFiles?.some(
-      (sibling) => 
-        sibling.id !== file.id && 
-        sibling.filename.toLowerCase() === inputValue.trim().toLowerCase()
-    ) || false;
+    return (
+      siblingFiles?.some(
+        (sibling) =>
+          sibling.id !== file.id &&
+          sibling.filename.toLowerCase() === inputValue.trim().toLowerCase(),
+      ) || false
+    );
   }, [isEditing, inputValue, file.filename, file.id, siblingFiles]);
 
   useEffect(() => {
@@ -153,12 +162,12 @@ const FilenameCell = ({
       setIsEditing(false);
       return;
     }
-    
+
     // 前端校验：检测同名冲突
     if (hasNameConflict) {
       return; // 不允许提交，保持编辑状态
     }
-    
+
     setIsRenaming(true);
     const success = await onRename(file, trimmedValue);
     setIsRenaming(false);
@@ -194,7 +203,7 @@ const FilenameCell = ({
       setIsUploading(false);
       // Reset file input
       if (fileInputRef.current) {
-        fileInputRef.current.value = '';
+        fileInputRef.current.value = "";
       }
     }
   };
@@ -225,21 +234,19 @@ const FilenameCell = ({
                 }
               }}
               className={`h-8 ${
-                hasNameConflict 
-                  ? "border-red-500 focus:border-red-500 focus:ring-red-500" 
+                hasNameConflict
+                  ? "border-red-500 focus:border-red-500 focus:ring-red-500"
                   : ""
               }`}
             />
             {hasNameConflict && (
-              <span className="text-xs text-red-500 mt-1">
-                文件名已存在
-              </span>
+              <span className="text-xs text-red-500 mt-1">文件名已存在</span>
             )}
           </div>
         ) : (
           <div className="flex items-center min-w-0 flex-1">
-            <span 
-              className="truncate mr-2 cursor-pointer hover:text-blue-600" 
+            <span
+              className="truncate mr-2 cursor-pointer hover:text-blue-600"
               title={displayName}
               onClick={(e) => {
                 e.stopPropagation();
@@ -250,7 +257,7 @@ const FilenameCell = ({
             </span>
           </div>
         )}
-        
+
         {/* 操作按钮区域 */}
         <div className="flex items-center gap-1 flex-shrink-0">
           <Button
@@ -266,7 +273,7 @@ const FilenameCell = ({
           >
             <Pencil size={14} />
           </Button>
-          
+
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -279,11 +286,8 @@ const FilenameCell = ({
                 <MoreHorizontal size={14} />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent 
-              align="end" 
-              className="w-48"
-            >
-              {!isDir && (
+            <DropdownMenuContent align="end" className="w-48">
+              {file.node_type === "file" && (
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
@@ -293,6 +297,18 @@ const FilenameCell = ({
                 >
                   <Upload className="mr-2 h-4 w-4" />
                   {isUploading ? "上传中..." : "重新上传"}
+                </DropdownMenuItem>
+              )}
+              {isResource && (
+                <DropdownMenuItem
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    await navigator.clipboard.writeText(file.resource_id);
+                    toast.success("资源标识已复制");
+                  }}
+                >
+                  <Copy className="mr-2 h-4 w-4" />
+                  复制资源标识
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
@@ -312,18 +328,18 @@ const FilenameCell = ({
                 className="text-red-600 focus:text-red-600"
               >
                 <Trash2 className="mr-2 h-4 w-4" />
-                删除
+                {isResource ? "移除引用" : "删除"}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        
-        {!isDir && (
+
+        {file.node_type === "file" && (
           <input
             ref={fileInputRef}
             type="file"
             onChange={handleFileChange}
-            style={{ display: 'none' }}
+            style={{ display: "none" }}
           />
         )}
       </div>
@@ -331,9 +347,13 @@ const FilenameCell = ({
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogTitle>
+              {isResource ? "确认移除资源引用" : "确认删除"}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              确定要删除 &ldquo;{file.filename}&rdquo; 吗？此操作不可撤销。
+              {isResource
+                ? `确定要移除“${file.filename}”的资源引用吗？此操作不会删除业务系统中的原始资源。`
+                : `确定要删除“${file.filename}”吗？此操作不可撤销。`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -345,7 +365,13 @@ const FilenameCell = ({
               disabled={isDeleting}
               className="bg-red-600 hover:bg-red-700"
             >
-              {isDeleting ? "删除中..." : "删除"}
+              {isDeleting
+                ? isResource
+                  ? "移除中..."
+                  : "删除中..."
+                : isResource
+                  ? "移除引用"
+                  : "删除"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -354,7 +380,13 @@ const FilenameCell = ({
   );
 };
 
-export const getColumns = ({ onRename, onDelete, onMove, onReUpload, siblingFiles }: GetColumnsOptions): ColumnDef<KnowledgeFile>[] => [
+export const getColumns = ({
+  onRename,
+  onDelete,
+  onMove,
+  onReUpload,
+  siblingFiles,
+}: GetColumnsOptions): ColumnDef<KnowledgeFile>[] => [
   {
     accessorKey: "filename",
     header: "名称",
@@ -374,9 +406,11 @@ export const getColumns = ({ onRename, onDelete, onMove, onReUpload, siblingFile
     accessorKey: "extension",
     header: "类型",
     accessorFn: (row) => {
-      const isDir = row.is_dir;
-      if (isDir) {
+      if (row.node_type === "directory") {
         return "文件夹";
+      }
+      if (row.node_type === "resource") {
+        return row.resource_id.split(":", 1)[0] || "资源";
       }
       const extension = row.extension;
       if (extension) {
@@ -452,8 +486,7 @@ export const getColumns = ({ onRename, onDelete, onMove, onReUpload, siblingFile
     header: "大小",
     cell: ({ row }) => {
       const bytes = row.getValue<number>("bytes");
-      const isDir = row.original.is_dir;
-      if (isDir) {
+      if (row.original.node_type !== "file") {
         return "";
       }
       if (bytes) {

--- a/web/src/app/admin/files/_components/data-table.tsx
+++ b/web/src/app/admin/files/_components/data-table.tsx
@@ -54,9 +54,11 @@ export function DataTable<TValue>({
   const allExtensions = Array.from(
     new Set(
       data.map((row) => {
-        const isDir = row.is_dir;
-        if (isDir) {
+        if (row.node_type === "directory") {
           return "文件夹";
+        }
+        if (row.node_type === "resource") {
+          return row.resource_id.split(":", 1)[0] || "资源";
         }
         const extension = row.extension;
         if (extension) {
@@ -126,9 +128,7 @@ export function DataTable<TValue>({
             </SelectTrigger>
             <SelectContent>
               {allExtensions.includes("文件夹") && (
-                <SelectItem value="文件夹">
-                  文件夹
-                </SelectItem>
+                <SelectItem value="文件夹">文件夹</SelectItem>
               )}
               {allExtensions.filter((item) => item !== "文件夹").length > 0 && (
                 <SelectGroup>
@@ -136,10 +136,7 @@ export function DataTable<TValue>({
                   {allExtensions
                     .filter((item) => item !== "文件夹")
                     .map((item, index) => (
-                      <SelectItem
-                        value={item}
-                        key={index}
-                      >
+                      <SelectItem value={item} key={index}>
                         {item}
                       </SelectItem>
                     ))}

--- a/web/src/app/admin/files/_components/move-folder-dialog.tsx
+++ b/web/src/app/admin/files/_components/move-folder-dialog.tsx
@@ -58,7 +58,7 @@ export function MoveFolderDialog({
         ancestor_id: ancestorId,
         space_code: spaceCode,
       });
-      setDirectories(res.data.filter((item) => item.is_dir));
+      setDirectories(res.data.filter((item) => item.node_type === "directory"));
       setLoading(false);
     },
     [spaceCode],

--- a/web/src/app/admin/files/page.tsx
+++ b/web/src/app/admin/files/page.tsx
@@ -82,9 +82,9 @@ const Page = () => {
   const router = useRouter();
   const onClickFile = useThrottleFn(
     (file: KnowledgeFile) => {
-      if (file.is_dir) {
+      if (file.node_type === "directory") {
         enterFolder(file, currentWorkspace?.spaceCode);
-      } else {
+      } else if (file.node_type === "file") {
         if (file.extension === "rageval") {
           router.push(`/rageval-preview?fileId=${file.id}`);
           return;
@@ -133,7 +133,9 @@ const Page = () => {
     async (file: KnowledgeFile) => {
       const success = await deleteFile(file, currentDir.id);
       if (success) {
-        toast.success("删除成功");
+        toast.success(
+          file.node_type === "resource" ? "资源引用已移除" : "删除成功",
+        );
       }
       return success;
     },

--- a/web/src/lib/types/file.ts
+++ b/web/src/lib/types/file.ts
@@ -10,6 +10,8 @@ export type KnowledgeFile = {
   dom_tree_file_id: string;
   mime_type: string;
   is_dir: boolean;
+  node_type: "file" | "directory" | "resource";
+  resource_id: string;
 };
 
 export interface DatasetFile {

--- a/web/src/request/files.ts
+++ b/web/src/request/files.ts
@@ -32,10 +32,10 @@ export async function findFiles(params: FindFilesParams) {
     return {
       ...res.data,
       data: res.data.data.sort((a, b) => {
-        if (a.is_dir && !b.is_dir) {
+        if (a.node_type === "directory" && b.node_type !== "directory") {
           return -1;
         }
-        if (!a.is_dir && b.is_dir) {
+        if (a.node_type !== "directory" && b.node_type === "directory") {
           return 1;
         }
         return b.created_at - a.created_at;


### PR DESCRIPTION
<!-- issue-flow:source-issue=71 -->
<!-- issue-flow:source source_task_id=task-cmsmtmb1v049t3f1ggvnda7wf source_runtime=agentrix -->
## Source issue

- #71

## Summary

- Add `node_type` and `resource_id` to the file model and all user, temp, and system physical tables; no resource-specific index is added because current queries do not use one.
- Migrate every previously rolled `file_temp_<key>` and `file_system_<key>` table recorded in `file_sharding`, because reads continue routing historical temp/system file IDs to those tables and jOOQ selects the new columns there. Only the required columns are added; no directory backfill is performed on temp/system shards because those file types do not host directory nodes.
- Add `POST /v1/files/resources` for registering resource references in root or directory locations with namespace-formatted resource IDs and an optional `purpose` validated against the existing file/directory purpose allowlist.
- Document that `resource_id` is intentionally non-unique: the same business resource may be referenced from multiple directory locations, and removing one node does not affect other references or the original resource.
- Return stable node metadata from unified queries, add `resource` page filtering, and keep OpenAI-compatible `GET /v1/files` free of resource nodes.
- Centralize content capability checks so resources cannot reach upload replacement, URL/content/preview, DOM tree, PDF/crop, progress, or dataset import processing paths.
- Make `requireContentFile` return the validated `FileDB` and add validated-object overloads for storage URL, preview, stream, content update, and progress operations, so API paths reuse the initial lookup instead of querying the same file again.
- Broadcast the complete resource lifecycle through the existing `FILE_CREATED`, `FILE_UPDATED`, and `FILE_DELETED` events with the same broadcast-status callbacks as files and directories.
- Update the admin file view with resource icons, namespace display, identifier copying, resource-safe actions, removal wording, and directory-only navigation targets.
- Make rolling deployment safe by treating `is_dir=1` as authoritative even when an old instance writes the new `node_type` column's default `file`; page `dir|file|resource` filters follow the same precedence.
- Add and adapt controller, service, repository, and node-type tests covering resource creation, purpose validation, ancestor restrictions, lifecycle broadcasts, content isolation, storage non-interaction, mixed-version directory writes, single-query content validation, and pagination across all three node types.
- Cover `type=resource` as a valid pagination request, unfiltered mixed directory/file/resource responses, and real H2 repository filtering with matching result sets and totals for `dir`, `file`, and `resource`.
- Configure pagination's standalone `MockMvc` with the same snake_case Jackson naming strategy as production, so `node_type` and `resource_id` response assertions validate the real API contract rather than test-only camelCase output.
- Share valid parent-directory setup through `FileControllerTestFixture.stubDirectory(...)` and remove the page test's contradictory `is_dir=1, node_type=file` local override.
- Deviation from the approved plan: #63 is not present on the current `develop`, so this implementation intentionally uses the existing `file_closure` write path instead of `file_entry`, as allowed by the plan. No separate resource tree was introduced.

## Validation

- `cd web && corepack pnpm run build` — passed.
- Changed frontend files: ESLint with `--max-warnings 0` — passed.
- Changed frontend files: Prettier check — passed.
- User-run backend suite before test adaptations: 115 tests executed, 107 passed, 8 failed. The six ancestor-validation failures were addressed by supplying valid directory fixtures to the affected mkdir/page tests, and the two message failures were updated to include `resource`.
- User-run targeted regression after pagination coverage: 42 tests executed, 4 failed because the standalone pagination test used a default camelCase `ObjectMapper`; commit `a2d4fbd` configures `PropertyNamingStrategy.SNAKE_CASE` while preserving the production-contract `node_type` and `resource_id` assertions.
- Pagination controller tests assert mixed three-node responses and totals, `type=resource` response metadata and totals, and filtered `dir`/`file` response types and totals.
- H2 repository pagination coverage inserts one directory, one file, and one resource under the same ancestor; the unfiltered query asserts all three IDs and node types with total 3, while each type filter asserts one matching row and total 1.
- `git diff --check`, staged `git diff --cached --check`, and `git show --check` — passed for the latest mapper correction.
- Static scan confirmed no controller test fixture combines `is_dir=1` with `node_type=file` after commit `88e6c6a`.
- Static migration review confirmed the cursor covers every non-base `temp`/`system` record in `file_sharding` and generates `ALTER TABLE file_<type>_<key>` statements adding both required columns.
- Static call-site scan confirmed API paths that call `requireContentFile` pass its `FileDB` result to subsequent content operations instead of re-fetching by file ID.
- Added a service assertion that resource URL rejection performs exactly one file query and never reaches storage.
- Confirmed `idx_resource` is absent from the API migration and generated code.
- Added service tests asserting `FILE_CREATED`, `FILE_UPDATED`, and `FILE_DELETED` broadcasts for resource nodes.
- Added controller coverage for accepted and unsupported resource `purpose` values.
- `cd web && corepack pnpm run type-check` — blocked by existing missing PNG module declarations for `import-dataset-demo.png` and `logo-site.png`; no errors were reported from changed files before those repository-level failures.
- `cd web && corepack pnpm run lint:check` — blocked because the repository script invokes `next lint --max-warnings 0`, which Next.js 16 does not support; direct ESLint validation passed.
- The backend suite could not be rerun locally after the test changes because Java and Maven are unavailable in this environment. Live MySQL migration execution is also unavailable because MySQL/MariaDB clients and Docker are absent.
