### PR TITLE
Build #76: Classify vision files as temp

### DIFF
--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -743,6 +743,9 @@ public class FileRepo implements BaseRepo {
             db.execute(createTableLikeSql(FILE.getName(), FileType.SYSTEM.getType(), key));
         } else if(fileType == FileType.TEMP) {
             db.execute(createTableLikeSql(FILE.getName(), FileType.TEMP.getType(), key));
+            // temp 分片上存在需要进度追踪的文件（如 vision、assistants_chat），
+            // 滚表时必须同步创建对应的进度分表，否则进度读写会因缺表失败
+            db.execute(createTableLikeSql(FILE_PROGRESS.getName(), FileType.TEMP.getType(), key));
         }
 
         addFileSharding(keyTime, lastKey, key, type);

--- a/api/src/main/java/com/ke/bella/files/utils/FilePurposeClassifier.java
+++ b/api/src/main/java/com/ke/bella/files/utils/FilePurposeClassifier.java
@@ -21,7 +21,6 @@ public class FilePurposeClassifier {
     static {
         // User files
         USER_PURPOSES.add(FilePurpose.ASSISTANTS.getValue());
-        USER_PURPOSES.add(FilePurpose.VISION.getValue());
         USER_PURPOSES.add(FilePurpose.USER_DATA.getValue());
 
         // System files
@@ -35,6 +34,7 @@ public class FilePurposeClassifier {
         TEMP_PURPOSES.add(FilePurpose.FINE_TUNE.getValue());
         TEMP_PURPOSES.add(FilePurpose.EVALS.getValue());
         TEMP_PURPOSES.add(FilePurpose.ASSISTANTS_CHAT.getValue());
+        TEMP_PURPOSES.add(FilePurpose.VISION.getValue());
 
         // Progress trackable purposes
         PROGRESS_TRACKABLE_PURPOSES.add(FilePurpose.ASSISTANTS.getValue());

--- a/api/src/test/java/com/ke/bella/files/utils/FilePurposeClassifierTest.java
+++ b/api/src/test/java/com/ke/bella/files/utils/FilePurposeClassifierTest.java
@@ -1,0 +1,30 @@
+package com.ke.bella.files.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ke.bella.files.enums.FilePurpose;
+import com.ke.bella.files.enums.FileType;
+
+public class FilePurposeClassifierTest {
+
+    @Test
+    public void visionPurposeIsClassifiedAsTemp() {
+        assertEquals(FileType.TEMP, FilePurposeClassifier.classify(FilePurpose.VISION.getValue()));
+    }
+
+    @Test
+    public void visionPurposeIsAllowedButNotAUserPurpose() {
+        assertTrue(FilePurposeClassifier.allowedPurposes().contains(FilePurpose.VISION.getValue()));
+        assertFalse(FilePurposeClassifier.isUserFile("file-vision-t"));
+    }
+
+    @Test
+    public void visionPurposeRemainsProgressTrackable() {
+        assertTrue(FilePurposeClassifier.allowedProgressTrackablePurposes()
+                .contains(FilePurpose.VISION.getValue()));
+    }
+}


### PR DESCRIPTION
<!-- issue-flow:source-issue=76 -->
<!-- issue-flow:source source_task_id=task-cmsrc45gf024r2f1rhk1he197 source_runtime=agentrix -->
Source issue: #76

## Summary
- Move `vision` from `USER_PURPOSES` to `TEMP_PURPOSES` so `FilePurposeClassifier.classify("vision")` returns `FileType.TEMP`.
- Keep `vision` in `PROGRESS_TRACKABLE_PURPOSES` to preserve existing progress tracking behavior.
- Add regression tests covering temporary classification, allowed purpose membership, non-user file classification, and progress tracking compatibility.

## Validation
- `git diff --check` passed.
- Java tests could not run because this environment has neither `mvnw` nor the `mvn`/Java toolchain installed.
