### PR TITLE
Build #83: Fix temp and system file sharding counts

### DIFF
--- a/api/src/main/java/com/ke/bella/files/FileShardingCountUpdator.java
+++ b/api/src/main/java/com/ke/bella/files/FileShardingCountUpdator.java
@@ -83,8 +83,13 @@ public class FileShardingCountUpdator {
             long v = d.get();
             if(v > 0) {
                 LOGGER.info("update file {} count, sharding: {}, delta: {}", type, k, v);
-                repo.increaseFileShardingCount(k, v, type);
-                d.addAndGet(-v);
+                int updatedRows = repo.increaseFileShardingCount(k, v, type);
+                if(updatedRows == 1) {
+                    d.addAndGet(-v);
+                } else {
+                    LOGGER.error("file sharding count update missed target, type: {}, physical sharding: {}, delta: {}, updated rows: {}",
+                            type, k, v, updatedRows);
+                }
             }
         });
     }

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -874,13 +874,28 @@ public class FileRepo implements BaseRepo {
                 .execute();
     }
 
-    public void increaseFileShardingCount(String key, long delta, String type) {
-        db.update(FILE_SHARDING)
+    public int increaseFileShardingCount(String physicalShardingKey, long delta, String type) {
+        String metadataKey = toFileShardingMetadataKey(physicalShardingKey, type);
+        return db.update(FILE_SHARDING)
                 .set(FILE_SHARDING.COUNT, FILE_SHARDING.COUNT.plus(delta))
                 .set(FILE_SHARDING.MTIME, LocalDateTime.now())
-                .where(FILE_SHARDING.KEY.eq(key))
+                .where(FILE_SHARDING.KEY.eq(metadataKey))
                 .and(FILE_SHARDING.TYPE.eq(type))
                 .execute();
+    }
+
+    static String toFileShardingMetadataKey(String physicalShardingKey, String type) {
+        if(type.equals(physicalShardingKey)) {
+            return "";
+        }
+
+        String prefix = type + "_";
+        if(physicalShardingKey.startsWith(prefix)) {
+            return physicalShardingKey.substring(prefix.length());
+        }
+
+        throw new IllegalArgumentException(
+                "Invalid physical file sharding key: " + physicalShardingKey + ", type: " + type);
     }
 
     public Page<FileDB> pageFiles(PageFileOps ops) {

--- a/api/src/test/java/com/ke/bella/files/FileShardingCountUpdatorTest.java
+++ b/api/src/test/java/com/ke/bella/files/FileShardingCountUpdatorTest.java
@@ -1,0 +1,25 @@
+package com.ke.bella.files;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.ke.bella.files.db.repo.FileRepo;
+
+public class FileShardingCountUpdatorTest {
+    @Test
+    public void keepsDeltaWhenDatabaseUpdateMissesTarget() {
+        FileRepo repo = mock(FileRepo.class);
+        when(repo.increaseFileShardingCount("temp", 1, "temp")).thenReturn(0);
+        FileShardingCountUpdator updator = new FileShardingCountUpdator();
+        updator.repo = repo;
+
+        updator.increase("temp", "temp");
+        updator.flush();
+        updator.flush();
+
+        verify(repo, org.mockito.Mockito.times(2)).increaseFileShardingCount("temp", 1, "temp");
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoShardingCountTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoShardingCountTest.java
@@ -1,0 +1,71 @@
+package com.ke.bella.files.db.repo;
+
+import static com.ke.bella.files.db.Tables.FILE_SHARDING;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileRepoShardingCountTest {
+    private Connection connection;
+    private DSLContext dsl;
+    private FileRepo fileRepo;
+
+    @Before
+    public void setUp() throws Exception {
+        connection = DriverManager.getConnection(
+                "jdbc:h2:mem:fileRepoShardingCount;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "");
+        dsl = DSL.using(connection, SQLDialect.H2);
+        dsl.execute("create table file_sharding (type varchar(32) not null, `key` varchar(255) not null, "
+                + "count bigint not null, mtime timestamp, primary key (type, `key`))");
+        insert("temp", "");
+        insert("system", "");
+        insert("temp", "250815120000");
+        fileRepo = new FileRepo(dsl, new FileEntryRepo(dsl));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        connection.close();
+    }
+
+    @Test
+    public void increasesInitialTempAndSystemShardCounts() {
+        assertEquals(1, fileRepo.increaseFileShardingCount("temp", 2, "temp"));
+        assertEquals(1, fileRepo.increaseFileShardingCount("system", 3, "system"));
+        assertEquals(Long.valueOf(2), count("temp", ""));
+        assertEquals(Long.valueOf(3), count("system", ""));
+    }
+
+    @Test
+    public void increasesTimeSuffixedShardCountUsingMetadataKey() {
+        assertEquals(1, fileRepo.increaseFileShardingCount("temp_250815120000", 4, "temp"));
+        assertEquals(Long.valueOf(4), count("temp", "250815120000"));
+    }
+
+    @Test
+    public void reportsMissingShardWithoutUpdatingAnyRow() {
+        assertEquals(0, fileRepo.increaseFileShardingCount("system_250815120000", 4, "system"));
+    }
+
+    private void insert(String type, String key) {
+        dsl.insertInto(FILE_SHARDING)
+                .set(FILE_SHARDING.TYPE, type)
+                .set(FILE_SHARDING.KEY, key)
+                .set(FILE_SHARDING.COUNT, 0L)
+                .execute();
+    }
+
+    private Long count(String type, String key) {
+        return dsl.select(FILE_SHARDING.COUNT).from(FILE_SHARDING)
+                .where(FILE_SHARDING.TYPE.eq(type)).and(FILE_SHARDING.KEY.eq(key))
+                .fetchOne(FILE_SHARDING.COUNT);
+    }
+}


### PR DESCRIPTION
<!-- issue-flow:source-issue=83 -->
<!-- issue-flow:source source_task_id=task-cmsuac8zn07282f1r6oh8hj6e source_runtime=agentrix -->
## Source issue

#83

## Summary

- Convert the physical routing key returned by `FileRepo.addFile` (`temp`/`system` or `<type>_<timestamp>`) to the metadata key stored in `file_sharding` (empty string or `<timestamp>`) before updating counts.
- Return the affected-row count from `increaseFileShardingCount` and retain the in-memory delta with an error log when no shard row is updated, preventing silent loss and enabling retry/diagnosis.
- Add coverage for initial `temp` and `system` shards, a time-suffixed shard, missing-row reporting, and delta retention.
- No implementation deviation from the issue: the current code confirms the documented physical-key/metadata-key mismatch.

## Validation

- `git diff --cached --check` passed.
- Added JUnit coverage in `FileRepoShardingCountTest` and `FileShardingCountUpdatorTest`.
- Maven tests were not runnable because the environment does not provide `mvn` or a Maven wrapper.
