### PR TITLE
Build #85: Support metadata when creating directories

### DIFF
--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1050,6 +1050,8 @@ public class FileController {
 
         validateDirectoryName(op.getName());
         validateDescription(op.getDescription());
+        validateCitiesJson(op.getCities());
+        validateTagsJson(op.getTags());
         if(op.getPurpose() != null && !FilePurposeClassifier.allowedPurposes().contains(op.getPurpose())) {
             throw new IllegalArgumentException(
                     String.format("Unsupported purpose: '%s'. Supported purposes are: %s",
@@ -1066,7 +1068,8 @@ public class FileController {
                         String.format("Directory '%s' already exists in current directory, ancestor_id: '%s'", op.getName(), op.getAncestorId()));
             }
 
-            return fileService.mkdir(op.getName(), op.getAncestorId(), op.getDescription(), op.getPurpose());
+            return fileService.mkdir(op.getName(), op.getAncestorId(), op.getDescription(), op.getPurpose(),
+                    op.getMetadata(), op.getCities(), op.getTags());
         });
     }
 

--- a/api/src/main/java/com/ke/bella/files/protocol/FileSystemOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/FileSystemOps.java
@@ -29,6 +29,9 @@ public class FileSystemOps {
         private String name;
         private String description;
         private String purpose;
+        private String metadata;
+        private List<String> cities;
+        private List<String> tags;
     }
 
     @Data

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -655,7 +655,8 @@ public class FileService {
         }
     }
 
-    public OpenAIFile mkdir(String name, String ancestorId, String description, String purpose) {
+    public OpenAIFile mkdir(String name, String ancestorId, String description, String purpose, String metadata,
+            List<String> cities, List<String> tags) {
         String spaceCode = BellaContextHelper.getOperateSpaceCode();
 
         FileType fileType = FileType.DIRECTORY;
@@ -673,14 +674,14 @@ public class FileService {
         fileDB.setBytes(0L);
         fileDB.setSpaceCode(spaceCode);
         fileDB.setPurpose(purpose);
-        fileDB.setMetaData("{}");
+        fileDB.setMetaData(metadata == null ? "{}" : metadata);
         fileDB.setAkCode(akCode);
         fileDB.setIsDir(1);
         fileDB.setNodeType(NodeType.DIRECTORY.getValue());
         fileDB.setResourceId("");
         fileDB.setDescription(description == null ? "" : description);
-        fileDB.setCities("");
-        fileDB.setTags("");
+        fileDB.setCities(cities == null ? "" : JsonUtils.toJson(cities));
+        fileDB.setTags(tags == null ? "" : JsonUtils.toJson(tags));
 
         fileRepo.addFile(fileDB, ancestorId, fileType);
 
@@ -694,7 +695,7 @@ public class FileService {
         FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
         message.setEvent(EventType.FILE_CREATED);
         message.setData(openAIFile);
-        message.setMetadata("{}");
+        message.setMetadata(res.getMetaData());
         message.setUserId(BellaContextHelper.getOperatorUserId());
         message.setUserName(BellaContextHelper.getOperatorUserName());
         message.setAkCode(BellaContextHelper.getOperatorAkCode());

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerMkdirTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerMkdirTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 import org.junit.Before;
@@ -78,7 +79,7 @@ public class FileControllerMkdirTest {
                     return supplier.get();
                 });
         when(fileService.exists(spaceCode, ancestorId, dirName)).thenReturn(false);
-        when(fileService.mkdir(dirName, ancestorId, description, null)).thenReturn(createdDir);
+        when(fileService.mkdir(dirName, ancestorId, description, null, null, null, null)).thenReturn(createdDir);
 
         String body = "{\"name\":\"" + dirName + "\",\"ancestor_id\":\"" + ancestorId + "\",\"description\":\"" + description + "\"}";
 
@@ -92,7 +93,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.filename").value(dirName))
                 .andExpect(jsonPath("$.space_code").value(spaceCode));
 
-        verify(fileService).mkdir(dirName, ancestorId, description, null);
+        verify(fileService).mkdir(dirName, ancestorId, description, null, null, null, null);
     }
 
     @Test
@@ -116,7 +117,7 @@ public class FileControllerMkdirTest {
                     return supplier.get();
                 });
         when(fileService.exists(spaceCode, ancestorId, dirName)).thenReturn(false);
-        when(fileService.mkdir(dirName, ancestorId, description, purpose)).thenReturn(createdDir);
+        when(fileService.mkdir(dirName, ancestorId, description, purpose, null, null, null)).thenReturn(createdDir);
 
         String body = "{\"name\":\"" + dirName + "\",\"ancestor_id\":\"" + ancestorId + "\",\"description\":\"" + description + "\",\"purpose\":\""
                 + purpose + "\"}";
@@ -131,7 +132,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.filename").value(dirName))
                 .andExpect(jsonPath("$.space_code").value(spaceCode));
 
-        verify(fileService).mkdir(dirName, ancestorId, description, purpose);
+        verify(fileService).mkdir(dirName, ancestorId, description, purpose, null, null, null);
     }
 
     @Test
@@ -153,7 +154,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString(invalidPurpose)));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -180,7 +181,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString("already exists")))
                 .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString(dirName)));
 
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -218,7 +219,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value("name is required"));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -237,7 +238,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value("name is required"));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -251,7 +252,7 @@ public class FileControllerMkdirTest {
                 .andExpect(status().isInternalServerError());
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -271,7 +272,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString("whitespace")));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -296,7 +297,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString("too long")));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -322,7 +323,7 @@ public class FileControllerMkdirTest {
                 .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString("Description too long")));
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -341,7 +342,7 @@ public class FileControllerMkdirTest {
                 .andExpect(status().isBadRequest());
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -360,7 +361,7 @@ public class FileControllerMkdirTest {
                 .andExpect(status().isBadRequest());
 
         verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
-        verify(fileService, never()).mkdir(any(), any(), any(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -384,7 +385,7 @@ public class FileControllerMkdirTest {
                         return supplier.get();
                     });
             when(fileService.exists(spaceCode, ancestorId, dirName)).thenReturn(false);
-            when(fileService.mkdir(dirName, ancestorId, null, purpose)).thenReturn(createdDir);
+            when(fileService.mkdir(dirName, ancestorId, null, purpose, null, null, null)).thenReturn(createdDir);
 
             String body = "{\"name\":\"" + dirName + "\",\"ancestor_id\":\"" + ancestorId + "\",\"purpose\":\"" + purpose + "\"}";
 
@@ -398,5 +399,70 @@ public class FileControllerMkdirTest {
                     .andExpect(jsonPath("$.filename").value(dirName))
                     .andExpect(jsonPath("$.space_code").value(spaceCode));
         }
+    }
+
+    @Test
+    public void mkdir_Success_WithMetadataCitiesAndTags() throws Exception {
+        String spaceCode = "sp-a";
+        String ancestorId = "anc-1";
+        String dirName = "test-dir";
+        OpenAIFile createdDir = OpenAIFile.builder()
+                .id("dir-1")
+                .filename(dirName)
+                .spaceCode(spaceCode)
+                .metadata("{\"team\":\"search\"}")
+                .cities(Arrays.asList("beijing", "shanghai"))
+                .tags(Arrays.asList("prod", "important"))
+                .build();
+
+        when(fileUniquenessLock.executeWithLock(eq(spaceCode), eq(ancestorId), eq(dirName), anyLong(), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(4);
+                    return supplier.get();
+                });
+        when(fileService.exists(spaceCode, ancestorId, dirName)).thenReturn(false);
+        when(fileService.mkdir(dirName, ancestorId, "description", "assistants",
+                "{\"team\":\"search\"}", Arrays.asList("beijing", "shanghai"),
+                Arrays.asList("prod", "important"))).thenReturn(createdDir);
+
+        String body = "{\"name\":\"" + dirName + "\",\"ancestor_id\":\"" + ancestorId
+                + "\",\"description\":\"description\",\"purpose\":\"assistants\","
+                + "\"metadata\":\"{\\\"team\\\":\\\"search\\\"}\","
+                + "\"cities\":[\"beijing\",\"shanghai\"],\"tags\":[\"prod\",\"important\"]}";
+
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode(spaceCode).build());
+        mockMvc.perform(post("/v1/files/mkdir")
+                .header("X-BELLA-SPACE-CODE", spaceCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.metadata").value("{\"team\":\"search\"}"))
+                .andExpect(jsonPath("$.cities[0]").value("beijing"))
+                .andExpect(jsonPath("$.tags[1]").value("important"));
+
+        verify(fileService).mkdir(dirName, ancestorId, "description", "assistants",
+                "{\"team\":\"search\"}", Arrays.asList("beijing", "shanghai"),
+                Arrays.asList("prod", "important"));
+    }
+
+    @Test
+    public void mkdir_CitiesTooLong_BadRequest() throws Exception {
+        StringBuilder value = new StringBuilder();
+        for(int i = 0; i < 600; i++) {
+            value.append("a");
+        }
+        String body = "{\"name\":\"test-dir\",\"ancestor_id\":\"anc-1\",\"cities\":[\""
+                + value + "\"]}";
+
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+        mockMvc.perform(post("/v1/files/mkdir")
+                .header("X-BELLA-SPACE-CODE", "sp-a")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value(org.hamcrest.Matchers.containsString("cities total length")));
+
+        verify(fileUniquenessLock, never()).executeWithLock(any(), any(), any(), anyLong(), any());
+        verify(fileService, never()).mkdir(any(), any(), any(), any(), any(), any(), any());
     }
 }

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceResourceTest.java
@@ -148,4 +148,33 @@ public class FileServiceResourceTest {
         resource.setMtime(LocalDateTime.now());
         return resource;
     }
+
+    @Test
+    public void mkdirPersistsMetadataCitiesTagsAndBroadcastsFinalRecord() {
+        AtomicReference<FileDB> inserted = new AtomicReference<>();
+        when(fileRepo.addFile(any(FileDB.class), anyString(), any(FileType.class))).thenAnswer(invocation -> {
+            FileDB file = invocation.getArgument(0);
+            file.setCtime(LocalDateTime.now());
+            file.setMtime(LocalDateTime.now());
+            inserted.set(file);
+            return "1";
+        });
+        when(fileRepo.queryFile(anyString(), any(FileType.class))).thenAnswer(invocation -> inserted.get());
+
+        java.util.List<String> cities = java.util.Arrays.asList("beijing", "shanghai");
+        java.util.List<String> tags = java.util.Arrays.asList("prod", "important");
+        OpenAIFile directory = fileService.mkdir("Sales", "file-parent-1-d", "description", "assistants",
+                "{\"team\":\"search\"}", cities, tags);
+
+        assertEquals("{\"team\":\"search\"}", inserted.get().getMetaData());
+        assertEquals("[\"beijing\",\"shanghai\"]", inserted.get().getCities());
+        assertEquals("[\"prod\",\"important\"]", inserted.get().getTags());
+        assertEquals(cities, directory.getCities());
+        assertEquals(tags, directory.getTags());
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_CREATED.getValue(), messageCaptor.getValue().getEvent());
+        assertEquals(directory, messageCaptor.getValue().getData());
+        assertEquals("{\"team\":\"search\"}", messageCaptor.getValue().getMetadata());
+    }
 }


### PR DESCRIPTION
<!-- issue-flow:source-issue=85 -->
<!-- issue-flow:source source_task_id=task-cmsudfxfj04j62zxhcgmqbvyn source_runtime=agentrix -->
## Source issue

- #85 — mkdir 的时候支持传跟 file，resource 一样的元数据字段，比如 Metadata，tags 等

## Summary

- Extend `MkdirOp` and `POST /v1/files/mkdir` to accept optional `metadata`, `cities`, and `tags`.
- Reuse the existing 512-character JSON validation for `cities` and `tags` before ancestor checks, locking, or persistence.
- Persist the supplied directory metadata and serialized arrays, while preserving `{}`/empty-string defaults for omitted fields.
- Return the persisted values and align `FILE_CREATED` broadcast data and envelope metadata with the final database record.
- Add controller contract coverage and service persistence/broadcast coverage.
- No deviation from the implementation plan was necessary.

## Validation

- `git diff --check` passed.
- Could not run Maven tests because this environment has neither `mvn`/Maven Wrapper nor a Java runtime installed.
- Added targeted coverage in `FileControllerMkdirTest` and `FileServiceResourceTest` for successful metadata propagation, default-compatible calls, oversized `cities`, persistence, response conversion, and broadcast consistency.
