### PR TITLE
Build #53: Stabilize closure file list cursors

### DIFF
--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -388,15 +388,26 @@ public class FileRepo implements BaseRepo {
         }
         if(StringUtils.isNotEmpty(after)) {
             after = queryNewFileId(after);
-            LocalDateTime afterCtime = db(shardingKey).select(FILE.CTIME)
-                    .from(FILE)
+            FileDB afterFile = db(shardingKey).selectFrom(FILE)
                     .where(FILE.FILE_ID.eq(after))
-                    .fetchOneInto(LocalDateTime.class);
-            query = query.and("asc".equalsIgnoreCase(order) ? FILE.CTIME.gt(afterCtime) : FILE.CTIME.lt(afterCtime));
+                    .fetchOneInto(FileDB.class);
+            if(afterFile == null) {
+                return Collections.emptyList();
+            }
+            boolean isAsc = "asc".equalsIgnoreCase(order);
+            Condition sameIdAfterFile = FILE.ID.eq(afterFile.getId())
+                    .and(isAsc ? FILE.FILE_ID.gt(afterFile.getFileId()) : FILE.FILE_ID.lt(afterFile.getFileId()));
+            Condition sameTimeAfterId = FILE.CTIME.eq(afterFile.getCtime())
+                    .and((isAsc ? FILE.ID.gt(afterFile.getId()) : FILE.ID.lt(afterFile.getId())).or(sameIdAfterFile));
+            query = query.and(isAsc ? FILE.CTIME.gt(afterFile.getCtime()).or(sameTimeAfterId)
+                    : FILE.CTIME.lt(afterFile.getCtime()).or(sameTimeAfterId));
         }
 
+        boolean isAsc = "asc".equalsIgnoreCase(order);
         return query
-                .orderBy("asc".equalsIgnoreCase(order) ? FILE.CTIME.asc() : FILE.CTIME.desc())
+                .orderBy(isAsc ? FILE.CTIME.asc() : FILE.CTIME.desc(),
+                        isAsc ? FILE.ID.asc() : FILE.ID.desc(),
+                        isAsc ? FILE.FILE_ID.asc() : FILE.FILE_ID.desc())
                 .limit(limit)
                 .fetchInto(FileDB.class);
     }

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileEntryRepoTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileEntryRepoTest.java
@@ -317,6 +317,37 @@ public class FileEntryRepoTest {
         assertTrue(fileRepo.listFile(null, 2, "asc", missingCursorId, SOURCE_SPACE, null).isEmpty());
     }
 
+    @Test
+    public void closureListUsesStableCursorForEqualCtimesInBothDirections() {
+        FileDB first = addFile(SOURCE_SPACE, "closure-first.txt", null, "closure-cursor-first");
+        FileDB second = addFile(SOURCE_SPACE, "closure-second.txt", null, "closure-cursor-second");
+        FileDB third = addFile(SOURCE_SPACE, "closure-third.txt", null, "closure-cursor-third");
+        FileDB fourth = addFile(SOURCE_SPACE, "closure-fourth.txt", null, "closure-cursor-fourth");
+        DSLContext shardDsl = DSLContextHolder.get(FileRepo.getShardingKeyBySpaceCode(SOURCE_SPACE), dsl);
+        LocalDateTime sharedCtime = LocalDateTime.of(2026, 8, 9, 0, 0);
+        shardDsl.update(FILE).set(FILE.CTIME, sharedCtime).execute();
+
+        List<FileDB> ascFirstPage = fileRepo.listFile(null, 2, "asc", null, SOURCE_SPACE, null);
+        List<FileDB> ascSecondPage = fileRepo.listFile(null, 2, "asc",
+                ascFirstPage.get(ascFirstPage.size() - 1).getFileId(), SOURCE_SPACE, null);
+        assertEquals(2, ascFirstPage.size());
+        assertEquals(2, ascSecondPage.size());
+        assertEquals(java.util.Arrays.asList(first.getFileId(), second.getFileId(), third.getFileId(), fourth.getFileId()),
+                java.util.stream.Stream.concat(ascFirstPage.stream(), ascSecondPage.stream())
+                        .map(FileDB::getFileId).collect(Collectors.toList()));
+
+        List<FileDB> descFirstPage = fileRepo.listFile(null, 2, "desc", null, SOURCE_SPACE, null);
+        List<FileDB> descSecondPage = fileRepo.listFile(null, 2, "desc",
+                descFirstPage.get(descFirstPage.size() - 1).getFileId(), SOURCE_SPACE, null);
+        assertEquals(2, descFirstPage.size());
+        assertEquals(2, descSecondPage.size());
+        assertEquals(java.util.Arrays.asList(fourth.getFileId(), third.getFileId(), second.getFileId(), first.getFileId()),
+                java.util.stream.Stream.concat(descFirstPage.stream(), descSecondPage.stream())
+                        .map(FileDB::getFileId).collect(Collectors.toList()));
+        String missingCursorId = first.getFileId().replaceFirst("260808", "260807");
+        assertTrue(fileRepo.listFile(null, 2, "asc", missingCursorId, SOURCE_SPACE, null).isEmpty());
+    }
+
     private FileDB addDirectory(String spaceCode, String filename, String ancestorId, String seed) {
         return add(spaceCode, filename, ancestorId, seed, FileType.DIRECTORY, 1, NodeType.DIRECTORY, "");
     }


### PR DESCRIPTION
<!-- issue-flow:source-issue=53 -->
<!-- issue-flow:source source_task_id=task-cmsue15mc04mz2zxhdkvb7smw source_runtime=agentrix -->
Source issue: #53

## Summary
- Stabilize the closure read path for `GET /v1/files` by ordering on `ctime`, file database `id`, and `file_id`.
- Align `after` filtering with the same composite ordering for both ascending and descending pagination.
- Return an empty page when the cursor file does not exist, preserving safe cursor behavior.
- Add closure-mode regression coverage for equal `ctime` values, both sort directions, and missing cursors.

The implementation follows the current entry-path behavior and does not deviate from the issue plan.

## Validation
- `git diff --check` passed.
- `mvn -pl api -Dtest=FileEntryRepoTest test` could not run because Maven is not installed in the execution environment.
