### PR TITLE
Build #45: Fix startup instance registration deadlock

### DIFF
--- a/api/src/main/java/com/ke/bella/files/db/repo/InstanceRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/InstanceRepo.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import javax.annotation.Resource;
 
 import org.jooq.DSLContext;
-import org.jooq.ResultQuery;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,20 +44,17 @@ public class InstanceRepo {
     }
 
     private InstanceRecord findIdle() {
-        InstanceRecord rec = idleInstanceQuery(db).fetchOne();
+        InstanceRecord rec = db.selectFrom(INSTANCE)
+                .where(INSTANCE.STATUS.eq(0))
+                .orderBy(INSTANCE.ID)
+                .limit(1)
+                .forUpdate()
+                .fetchOne();
         if(rec == null) {
             rec = INSTANCE.newRecord();
             rec.set(INSTANCE.CTIME, LocalDateTime.now());
             rec.attach(db.configuration());
         }
         return rec;
-    }
-
-    static ResultQuery<InstanceRecord> idleInstanceQuery(DSLContext db) {
-        return db.selectFrom(INSTANCE)
-                .where(INSTANCE.STATUS.eq(0))
-                .orderBy(INSTANCE.ID)
-                .limit(1)
-                .forUpdate();
     }
 }

--- a/api/src/main/java/com/ke/bella/files/db/repo/InstanceRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/InstanceRepo.java
@@ -1,13 +1,14 @@
 package com.ke.bella.files.db.repo;
 
 import static com.ke.bella.files.db.Tables.INSTANCE;
-import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 import java.time.LocalDateTime;
 
 import javax.annotation.Resource;
 
 import org.jooq.DSLContext;
+import org.jooq.ResultQuery;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +19,7 @@ public class InstanceRepo {
     @Resource
     private DSLContext db;
 
-    @Transactional(isolation = SERIALIZABLE)
+    @Transactional(isolation = READ_COMMITTED)
     public Long register(String ip, int port) {
         InstanceRecord rec = db.selectFrom(INSTANCE)
                 .where(INSTANCE.IP.eq(ip).and(INSTANCE.PORT.eq(port))).fetchOne();
@@ -44,13 +45,20 @@ public class InstanceRepo {
     }
 
     private InstanceRecord findIdle() {
-        InstanceRecord rec = db.selectFrom(INSTANCE)
-                .where(INSTANCE.STATUS.eq(0)).limit(1).fetchAny();
+        InstanceRecord rec = idleInstanceQuery(db).fetchOne();
         if(rec == null) {
             rec = INSTANCE.newRecord();
             rec.set(INSTANCE.CTIME, LocalDateTime.now());
             rec.attach(db.configuration());
         }
         return rec;
+    }
+
+    static ResultQuery<InstanceRecord> idleInstanceQuery(DSLContext db) {
+        return db.selectFrom(INSTANCE)
+                .where(INSTANCE.STATUS.eq(0))
+                .orderBy(INSTANCE.ID)
+                .limit(1)
+                .forUpdate();
     }
 }

--- a/api/src/test/java/com/ke/bella/files/db/repo/InstanceRepoTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/InstanceRepoTest.java
@@ -1,37 +1,205 @@
 package com.ke.bella.files.db.repo;
 
+import static com.ke.bella.files.db.Tables.INSTANCE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.lang.reflect.Method;
-import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import javax.sql.DataSource;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.jooq.DSLContext;
+import org.jooq.ExecuteContext;
 import org.jooq.SQLDialect;
-import org.jooq.impl.DSL;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.jooq.impl.DefaultExecuteListener;
+import org.jooq.impl.DefaultExecuteListenerProvider;
+import org.junit.Before;
 import org.junit.Test;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.runner.RunWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.ke.bella.files.db.tables.records.InstanceRecord;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = InstanceRepoTest.TestConfig.class)
 public class InstanceRepoTest {
+    @javax.annotation.Resource
+    private DSLContext db;
 
-    @Test
-    public void registerUsesReadCommittedIsolation() throws NoSuchMethodException {
-        Method register = InstanceRepo.class.getMethod("register", String.class, int.class);
-        Transactional transactional = register.getAnnotation(Transactional.class);
+    @javax.annotation.Resource
+    private InstanceRepo instanceRepo;
 
-        assertNotNull(transactional);
-        assertEquals(Isolation.READ_COMMITTED, transactional.isolation());
+    @javax.annotation.Resource
+    private BlockingIdleSelectListener blockingIdleSelectListener;
+
+    @Before
+    public void setup() {
+        blockingIdleSelectListener.reset();
+        db.execute("drop table if exists instance");
+        db.execute("create table instance ("
+                + "id bigint auto_increment primary key, "
+                + "ip varchar(64) not null default '', "
+                + "port int not null default 0, "
+                + "status int not null default 0, "
+                + "ctime timestamp not null default current_timestamp, "
+                + "mtime timestamp not null default current_timestamp)");
     }
 
     @Test
-    public void idleInstanceQueryUsesMySql57CompatibleUpdateLock() {
-        String sql = InstanceRepo.idleInstanceQuery(DSL.using(SQLDialect.MYSQL))
-                .getSQL()
-                .toLowerCase(Locale.ROOT);
+    public void registerCreatesInstanceWhenNoIdleRecordExists() {
+        Long id = instanceRepo.register("10.0.0.1", 8080);
 
-        assertTrue(sql.contains("for update"));
-        assertFalse(sql.contains("skip locked"));
+        InstanceRecord record = db.selectFrom(INSTANCE).where(INSTANCE.ID.eq(id)).fetchOne();
+        assertEquals("10.0.0.1", record.getIp());
+        assertEquals(Integer.valueOf(8080), record.getPort());
+        assertEquals(Integer.valueOf(1), record.getStatus());
+        assertEquals(1, db.fetchCount(INSTANCE));
+    }
+
+    @Test
+    public void registerReusesExistingEndpoint() {
+        insertInstance(1L, "10.0.0.2", 8081, 0);
+
+        Long id = instanceRepo.register("10.0.0.2", 8081);
+
+        assertEquals(Long.valueOf(1L), id);
+        assertEquals(Integer.valueOf(1), db.selectFrom(INSTANCE)
+                .where(INSTANCE.ID.eq(id)).fetchOne().getStatus());
+        assertEquals(1, db.fetchCount(INSTANCE));
+    }
+
+    @Test
+    public void concurrentRegistrationsClaimDifferentIdleRecords() throws Exception {
+        insertInstance(1L, "", 0, 0);
+        insertInstance(2L, "", 0, 0);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<Long> first = executor.submit(() -> {
+                Thread.currentThread().setName(BlockingIdleSelectListener.FIRST_REGISTRATION_THREAD);
+                return instanceRepo.register("10.0.0.3", 8082);
+            });
+            assertTrue(blockingIdleSelectListener.awaitFirstSelection());
+
+            Future<Long> second = executor.submit(() -> instanceRepo.register("10.0.0.4", 8083));
+            try {
+                second.get(200, TimeUnit.MILLISECONDS);
+                fail("the second registration should wait for the locked idle record");
+            } catch(TimeoutException expected) {
+            }
+
+            blockingIdleSelectListener.releaseFirstRegistration();
+            Long firstId = first.get(2, TimeUnit.SECONDS);
+            Long secondId = second.get(2, TimeUnit.SECONDS);
+
+            assertNotEquals(firstId, secondId);
+            assertEquals(Integer.valueOf(1), db.selectFrom(INSTANCE)
+                    .where(INSTANCE.ID.eq(firstId)).fetchOne().getStatus());
+            assertEquals(Integer.valueOf(1), db.selectFrom(INSTANCE)
+                    .where(INSTANCE.ID.eq(secondId)).fetchOne().getStatus());
+        } finally {
+            blockingIdleSelectListener.releaseFirstRegistration();
+            executor.shutdownNow();
+        }
+    }
+
+    private void insertInstance(Long id, String ip, int port, int status) {
+        db.insertInto(INSTANCE)
+                .set(INSTANCE.ID, id)
+                .set(INSTANCE.IP, ip)
+                .set(INSTANCE.PORT, port)
+                .set(INSTANCE.STATUS, status)
+                .execute();
+    }
+
+    public static class BlockingIdleSelectListener extends DefaultExecuteListener {
+        private static final String FIRST_REGISTRATION_THREAD = "first-instance-registration";
+        private CountDownLatch firstSelection;
+        private CountDownLatch releaseFirst;
+
+        public void reset() {
+            firstSelection = new CountDownLatch(1);
+            releaseFirst = new CountDownLatch(1);
+        }
+
+        public boolean awaitFirstSelection() throws InterruptedException {
+            return firstSelection.await(2, TimeUnit.SECONDS);
+        }
+
+        public void releaseFirstRegistration() {
+            releaseFirst.countDown();
+        }
+
+        @Override
+        public void fetchEnd(ExecuteContext context) {
+            if(FIRST_REGISTRATION_THREAD.equals(Thread.currentThread().getName())
+                    && context.sql() != null
+                    && context.sql().toLowerCase().contains("for update")) {
+                firstSelection.countDown();
+                try {
+                    releaseFirst.await(2, TimeUnit.SECONDS);
+                } catch(InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+    }
+
+    @Configuration
+    @EnableTransactionManagement(proxyTargetClass = true)
+    public static class TestConfig {
+        @Bean
+        public DataSource dataSource() {
+            JdbcDataSource dataSource = new JdbcDataSource();
+            dataSource.setURL("jdbc:h2:mem:instanceRepo;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1");
+            dataSource.setUser("sa");
+            return dataSource;
+        }
+
+        @Bean
+        public PlatformTransactionManager transactionManager(DataSource dataSource) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+
+        @Bean
+        public BlockingIdleSelectListener blockingIdleSelectListener() {
+            return new BlockingIdleSelectListener();
+        }
+
+        @Bean
+        public DSLContext dslContext(DataSource dataSource, BlockingIdleSelectListener listener) {
+            DefaultConfiguration configuration = new DefaultConfiguration();
+            configuration.setSQLDialect(SQLDialect.H2);
+            configuration.setConnectionProvider(new org.jooq.impl.DataSourceConnectionProvider(
+                    new TransactionAwareDataSourceProxy(dataSource)));
+            configuration.set(new DefaultExecuteListenerProvider(listener));
+            return new DefaultDSLContext(configuration);
+        }
+
+        @Bean
+        public InstanceRepo instanceRepo(DSLContext db) {
+            InstanceRepo repo = new InstanceRepo();
+            ReflectionTestUtils.setField(repo, "db", db);
+            return repo;
+        }
     }
 }

--- a/api/src/test/java/com/ke/bella/files/db/repo/InstanceRepoTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/InstanceRepoTest.java
@@ -4,8 +4,8 @@ import static com.ke.bella.files.db.Tables.INSTANCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -100,15 +100,17 @@ public class InstanceRepoTest {
             assertTrue(blockingIdleSelectListener.awaitFirstSelection());
 
             Future<Long> second = executor.submit(() -> instanceRepo.register("10.0.0.4", 8083));
+            Long secondId = null;
             try {
-                second.get(200, TimeUnit.MILLISECONDS);
-                fail("the second registration should wait for the locked idle record");
+                secondId = second.get(200, TimeUnit.MILLISECONDS);
             } catch(TimeoutException expected) {
             }
 
             blockingIdleSelectListener.releaseFirstRegistration();
             Long firstId = first.get(2, TimeUnit.SECONDS);
-            Long secondId = second.get(2, TimeUnit.SECONDS);
+            if(secondId == null) {
+                secondId = second.get(2, TimeUnit.SECONDS);
+            }
 
             assertNotEquals(firstId, secondId);
             assertEquals(Integer.valueOf(1), db.selectFrom(INSTANCE)
@@ -151,8 +153,7 @@ public class InstanceRepoTest {
         @Override
         public void fetchEnd(ExecuteContext context) {
             if(FIRST_REGISTRATION_THREAD.equals(Thread.currentThread().getName())
-                    && context.sql() != null
-                    && context.sql().toLowerCase().contains("for update")) {
+                    && isIdleSelection(context.sql())) {
                 firstSelection.countDown();
                 try {
                     releaseFirst.await(2, TimeUnit.SECONDS);
@@ -161,6 +162,11 @@ public class InstanceRepoTest {
                     throw new IllegalStateException(e);
                 }
             }
+        }
+
+        private boolean isIdleSelection(String sql) {
+            return sql != null
+                    && sql.toLowerCase(Locale.ROOT).contains("where \"instance\".\"status\"");
         }
     }
 

--- a/api/src/test/java/com/ke/bella/files/db/repo/InstanceRepoTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/InstanceRepoTest.java
@@ -1,0 +1,37 @@
+package com.ke.bella.files.db.repo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.Test;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+public class InstanceRepoTest {
+
+    @Test
+    public void registerUsesReadCommittedIsolation() throws NoSuchMethodException {
+        Method register = InstanceRepo.class.getMethod("register", String.class, int.class);
+        Transactional transactional = register.getAnnotation(Transactional.class);
+
+        assertNotNull(transactional);
+        assertEquals(Isolation.READ_COMMITTED, transactional.isolation());
+    }
+
+    @Test
+    public void idleInstanceQueryUsesMySql57CompatibleUpdateLock() {
+        String sql = InstanceRepo.idleInstanceQuery(DSL.using(SQLDialect.MYSQL))
+                .getSQL()
+                .toLowerCase(Locale.ROOT);
+
+        assertTrue(sql.contains("for update"));
+        assertFalse(sql.contains("skip locked"));
+    }
+}


### PR DESCRIPTION
<!-- issue-flow:source-issue=45 -->
<!-- issue-flow:source source_task_id=task-cmsvw3fg5077u2f1r2r389qs7 source_runtime=agentrix -->
## Source issue

- #45

## Summary

- Change instance registration transactions from `SERIALIZABLE` to explicit `READ_COMMITTED` to avoid missing-record gap-lock contention during concurrent startup.
- Lock idle instance selection with deterministic `ORDER BY id ... FOR UPDATE`, so concurrent registrars cannot claim the same idle row.
- Preserve creation when no idle record exists and reuse an existing matching `(ip, port)` record.
- Deviation from the issue suggestion: do not use `SKIP LOCKED` because the production database may be older than MySQL 8.0. The selected `FOR UPDATE` approach remains compatible with MySQL 5.7, at the cost of waiting for the currently selected idle row instead of skipping it.
- Add repository behavior tests backed by H2 and Spring transactions. The concurrency test pauses the first registration after its idle-row query without checking for `FOR UPDATE`, so the old implementation reproduces duplicate claiming or lock failure while the fixed implementation completes with different instance IDs.

## Validation

- `git diff --check` passed.
- Added `InstanceRepoTest` coverage for new-record creation, existing-endpoint reuse, and the old idle-record claim race.
- Maven tests were not executed locally because the runtime image contains neither Java nor Maven; attempts to provision a temporary JDK from Adoptium and Debian mirrors were unsuccessful/too slow. Remote CI should run the added test.
