### PR TITLE
Build #90: Isolate FileRepoShardingCountTest H2 state

### DIFF
--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoShardingCountTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoShardingCountTest.java
@@ -21,7 +21,7 @@ public class FileRepoShardingCountTest {
     @Before
     public void setUp() throws Exception {
         connection = DriverManager.getConnection(
-                "jdbc:h2:mem:fileRepoShardingCount;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "");
+                "jdbc:h2:mem:fileRepoShardingCount;MODE=MySQL;DB_CLOSE_DELAY=0", "sa", "");
         dsl = DSL.using(connection, SQLDialect.H2);
         dsl.execute("create table file_sharding (type varchar(32) not null, `key` varchar(255) not null, "
                 + "count bigint not null, mtime timestamp, primary key (type, `key`))");


### PR DESCRIPTION
<!-- issue-flow:source-issue=90 -->
<!-- issue-flow:source source_task_id=task-cmswnenp707iu2f1r7ocl14qo source_runtime=agentrix -->
Source issue: #90

## Summary
- Changed `FileRepoShardingCountTest` to use H2's default close behavior (`DB_CLOSE_DELAY=0`).
- Closing the test connection now discards the in-memory database, so each `@Before` starts with a fresh `file_sharding` table and tests no longer depend on execution order or retained table state.
- No deviation from the issue approach; the fix is implemented at the database lifecycle configuration point.

## Validation
- `git diff --check` passed.
- Could not run `mvn -pl api -Dtest=FileRepoShardingCountTest test` because Maven is not installed in the execution environment and the repository does not include a Maven wrapper.
