### PR TITLE
test: isolate H2 file sharding count tests

### DIFF
--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoShardingCountTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoShardingCountTest.java
@@ -21,7 +21,7 @@ public class FileRepoShardingCountTest {
     @Before
     public void setUp() throws Exception {
         connection = DriverManager.getConnection(
-                "jdbc:h2:mem:fileRepoShardingCount;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "");
+                "jdbc:h2:mem:fileRepoShardingCount;MODE=MySQL;DATABASE_TO_LOWER=TRUE", "sa", "");
         dsl = DSL.using(connection, SQLDialect.H2);
         dsl.execute("create table file_sharding (type varchar(32) not null, `key` varchar(255) not null, "
                 + "count bigint not null, mtime timestamp, primary key (type, `key`))");


### PR DESCRIPTION
close #90 
## Description

Fix `FileRepoShardingCountTest` failures in H2 by:

- enabling `DATABASE_TO_LOWER=TRUE` so unquoted DDL identifiers match the quoted lowercase names generated by jOOQ
- removing `DB_CLOSE_DELAY=-1` so the in-memory database is discarded when each test connection closes

This prevents both `Table "file_sharding" not found` and cross-test `Table "FILE_SHARDING" already exists` errors. Production code is unchanged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Component

- [x] 🔧 API (Backend)
- [x] 🧪 Tests

## Testing

- [x] Unit tests pass (`mvn test`)

**Test Configuration**:
- OS: macOS
- Java version: 1.8.0_462

Results:
- `mvn -Dtest=FileRepoShardingCountTest test`: 3 tests, 0 failures, 0 errors
- `mvn test`: 155 tests, 0 failures, 0 errors

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The change is limited to the H2 JDBC URL in `FileRepoShardingCountTest`.