### PR TITLE
Build #93: Skip broadcasts for non-chat temp files

### DIFF
--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -26,6 +26,7 @@ import com.ke.bella.files.db.repo.FileRepo;
 import com.ke.bella.files.db.repo.Page;
 import com.ke.bella.files.db.tables.pojos.FileDB;
 import com.ke.bella.files.db.tables.pojos.FileProgressDB;
+import com.ke.bella.files.enums.FilePurpose;
 import com.ke.bella.files.enums.FileType;
 import com.ke.bella.files.enums.NodeType;
 import com.ke.bella.files.protocol.BroadcastStatus;
@@ -95,6 +96,16 @@ public class FileService {
             LOGGER.error(msg, e);
             throw new IllegalStateException(msg, e);
         }
+    }
+
+    private void broadcast(FileDB fileDB, FileBroadcasting<?> message) {
+        FileType fileType = FileType.fromFileId(fileDB.getFileId());
+        if(fileType == FileType.TEMP && !FilePurpose.ASSISTANTS_CHAT.getValue().equals(fileDB.getPurpose())) {
+            return;
+        }
+        broadcastService.broadcast(message,
+                () -> updateBroadcastStatus(fileDB.getFileId(), BroadcastStatus.SUCCESS),
+                () -> updateBroadcastStatus(fileDB.getFileId(), BroadcastStatus.FAILED));
     }
 
     private OpenAIFile transferToOpenAIFile(FileDB fileDB) {
@@ -417,9 +428,7 @@ public class FileService {
         message.setUserId(BellaContextHelper.getOperatorUserId());
         message.setUserName(BellaContextHelper.getOperatorUserName());
         message.setAkCode(BellaContextHelper.getOperatorAkCode());
-        broadcastService.broadcast(message,
-                () -> updateBroadcastStatus(fileDB.getFileId(), BroadcastStatus.SUCCESS),
-                () -> updateBroadcastStatus(fileDB.getFileId(), BroadcastStatus.FAILED));
+        broadcast(fileDB, message);
 
         return openAIFile;
     }
@@ -511,8 +520,7 @@ public class FileService {
         message.setUserId(BellaContextHelper.getOperatorUserId());
         message.setUserName(BellaContextHelper.getOperatorUserName());
         message.setAkCode(BellaContextHelper.getOperatorAkCode());
-        broadcastService.broadcast(message, () -> updateBroadcastStatus(finalOpenAIFile.getId(), BroadcastStatus.SUCCESS),
-                () -> updateBroadcastStatus(finalOpenAIFile.getId(), BroadcastStatus.FAILED));
+        broadcast(fileDB, message);
 
         return finalOpenAIFile;
     }
@@ -550,9 +558,7 @@ public class FileService {
             message.setUserId(BellaContextHelper.getOperatorUserId());
             message.setUserName(BellaContextHelper.getOperatorUserName());
             message.setAkCode(BellaContextHelper.getOperatorAkCode());
-            broadcastService.broadcast(message,
-                    () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
-                    () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
+            broadcast(fileDB, message);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to update file status (indicating deletion), fileId: "
                     + fileId + ", status: " + FileStatus.DELETED, e);
@@ -699,8 +705,7 @@ public class FileService {
         message.setUserId(BellaContextHelper.getOperatorUserId());
         message.setUserName(BellaContextHelper.getOperatorUserName());
         message.setAkCode(BellaContextHelper.getOperatorAkCode());
-        broadcastService.broadcast(message, () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
-                () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
+        broadcast(res, message);
         return openAIFile;
     }
 
@@ -743,8 +748,7 @@ public class FileService {
         message.setUserId(BellaContextHelper.getOperatorUserId());
         message.setUserName(BellaContextHelper.getOperatorUserName());
         message.setAkCode(BellaContextHelper.getOperatorAkCode());
-        broadcastService.broadcast(message, () -> updateBroadcastStatus(fileId, BroadcastStatus.SUCCESS),
-                () -> updateBroadcastStatus(fileId, BroadcastStatus.FAILED));
+        broadcast(created, message);
         return resource;
     }
 

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -1,0 +1,109 @@
+package com.ke.bella.files.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ke.bella.files.db.repo.FileRepo;
+import com.ke.bella.files.db.tables.pojos.FileDB;
+import com.ke.bella.files.enums.FilePurpose;
+import com.ke.bella.files.enums.FileType;
+import com.ke.bella.files.protocol.EventType;
+import com.ke.bella.files.protocol.FileBroadcasting;
+import com.ke.bella.files.protocol.FileOps;
+import com.ke.bella.files.protocol.FileStatus;
+import com.ke.bella.files.protocol.Scope;
+import com.ke.bella.files.service.broadcast.BroadcastService;
+import com.ke.bella.openapi.BellaContext;
+import com.ke.bella.openapi.Operator;
+
+public class FileServiceBroadcastTest {
+    private FileService fileService;
+    private FileRepo fileRepo;
+    private BroadcastService broadcastService;
+
+    @Before
+    public void setup() {
+        fileService = new FileService();
+        fileRepo = Mockito.mock(FileRepo.class);
+        broadcastService = Mockito.mock(BroadcastService.class);
+        ReflectionTestUtils.setField(fileService, "fileRepo", fileRepo);
+        ReflectionTestUtils.setField(fileService, "broadcastService", broadcastService);
+        BellaContext.setOperator(Operator.builder().userId(1L).userName("tester").spaceCode("sp-a").build());
+    }
+
+    @Test
+    public void finalizeUploadSkipsBroadcastForNonAssistantTempFiles() {
+        for (FilePurpose purpose : new FilePurpose[] {
+                FilePurpose.BATCH,
+                FilePurpose.TEMP,
+                FilePurpose.FINE_TUNE,
+                FilePurpose.EVALS,
+                FilePurpose.VISION }) {
+            fileService.finalizeFileUpload(tempFile(purpose), "{}");
+        }
+
+        verifyNoInteractions(broadcastService);
+        verifyNoInteractions(fileRepo);
+    }
+
+    @Test
+    public void finalizeUploadBroadcastsAssistantChatTempFile() {
+        FileDB file = tempFile(FilePurpose.ASSISTANTS_CHAT);
+
+        fileService.finalizeFileUpload(file, "{}");
+
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_CREATED.getValue(), messageCaptor.getValue().getEvent());
+    }
+
+    @Test
+    public void updateSkipsBroadcastForNonAssistantTempFile() {
+        FileDB file = tempFile(FilePurpose.VISION);
+        FileOps ops = FileOps.builder().fileId(file.getFileId()).filename("updated.png").build();
+        when(fileRepo.queryFile(file.getFileId(), FileType.TEMP)).thenReturn(file);
+
+        fileService.updateFile(ops, false, Scope.FILENAME);
+
+        verify(fileRepo, times(1)).updateFile(ops, false);
+        verifyNoInteractions(broadcastService);
+    }
+
+    @Test
+    public void deleteSkipsBroadcastForNonAssistantTempFile() {
+        FileDB file = tempFile(FilePurpose.FINE_TUNE);
+
+        fileService.delete(file);
+
+        ArgumentCaptor<FileOps> opsCaptor = ArgumentCaptor.forClass(FileOps.class);
+        verify(fileRepo).updateFile(opsCaptor.capture(), eq(false));
+        assertEquals(FileStatus.DELETED, opsCaptor.getValue().getStatus());
+        verifyNoInteractions(broadcastService);
+    }
+
+    private FileDB tempFile(FilePurpose purpose) {
+        FileDB file = new FileDB();
+        file.setFileId("file-test-t");
+        file.setFilename("test.txt");
+        file.setPurpose(purpose.getValue());
+        file.setMetaData("{}");
+        file.setBytes(1L);
+        file.setIsDir(0);
+        file.setCtime(LocalDateTime.now());
+        file.setMtime(LocalDateTime.now());
+        return file;
+    }
+}


### PR DESCRIPTION
<!-- issue-flow:source-issue=93 -->
<!-- issue-flow:source source_task_id=task-cmsy4haj100r52zxh7afy72l3 source_runtime=agentrix -->
## Source issue

- #93

## Summary

- Centralize file lifecycle broadcasting in `FileService` so every create, update, delete, directory, and resource path uses the same eligibility check.
- Skip broadcasting when the persisted file ID identifies `FileType.TEMP` and the purpose is not `assistants-chat`; skipped files do not register success or failure status callbacks.
- Preserve existing broadcasting for `assistants-chat` temporary files and all non-temporary files, directories, and resource nodes.
- Add unit coverage for all known non-chat temporary purposes plus representative create, update, delete, and retained `assistants-chat` behavior.

## Validation

- `git diff --cached --check` (passed before commit)
- `mvn -Dtest=FileServiceBroadcastTest,FileServiceResourceTest,FilePurposeClassifierTest test` (not run: the execution environment has neither Java nor Maven installed)
