### PR TITLE
Build #95: Add stable keys to file broadcasts

### DIFF
--- a/api/src/main/java/com/ke/bella/files/configuration/KafkaConfig.java
+++ b/api/src/main/java/com/ke/bella/files/configuration/KafkaConfig.java
@@ -19,6 +19,7 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.ke.bella.files.protocol.OpenAIFile;
 import com.ke.bella.files.service.broadcast.BroadcastService;
 import com.ke.bella.openapi.BellaContext;
 
@@ -58,7 +59,12 @@ public class KafkaConfig {
     public BroadcastService kafkaBroadcastService(KafkaTemplate<String, Object> kafkaTemplate) {
         return (message, successCallback, failCallback) -> {
             Map<String, Object> snapshot = BellaContext.snapshot();
-            kafkaTemplate.send(topic, message).addCallback(
+            OpenAIFile file = (OpenAIFile) message.getData();
+            String key = file.getSpaceCode();
+            if(key == null || key.isEmpty()) {
+                key = file.getId();
+            }
+            kafkaTemplate.send(topic, key, message).addCallback(
                     success -> {
                         BellaContext.replace(snapshot);
                         successCallback.run();

--- a/api/src/test/java/com/ke/bella/files/configuration/KafkaConfigTest.java
+++ b/api/src/test/java/com/ke/bella/files/configuration/KafkaConfigTest.java
@@ -1,0 +1,70 @@
+package com.ke.bella.files.configuration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+import com.ke.bella.files.protocol.FileBroadcasting;
+import com.ke.bella.files.protocol.OpenAIFile;
+import com.ke.bella.files.service.broadcast.BroadcastService;
+
+public class KafkaConfigTest {
+    private static final String TOPIC = "file-broadcast";
+
+    private KafkaTemplate<String, Object> kafkaTemplate;
+    private BroadcastService broadcastService;
+
+    @Before
+    public void setup() {
+        KafkaConfig kafkaConfig = new KafkaConfig();
+        kafkaTemplate = mock(KafkaTemplate.class);
+        ReflectionTestUtils.setField(kafkaConfig, "topic", TOPIC);
+        broadcastService = kafkaConfig.kafkaBroadcastService(kafkaTemplate);
+    }
+
+    @Test
+    public void broadcastsWithSpaceCodeAndRunsSuccessCallback() {
+        FileBroadcasting<OpenAIFile> message = message("file-1", "space-a");
+        SettableListenableFuture<SendResult<String, Object>> future = new SettableListenableFuture<>();
+        Runnable successCallback = mock(Runnable.class);
+        Runnable failCallback = mock(Runnable.class);
+        when(kafkaTemplate.send(TOPIC, "space-a", message)).thenReturn(future);
+
+        broadcastService.broadcast(message, successCallback, failCallback);
+        future.set(null);
+
+        verify(kafkaTemplate).send(TOPIC, "space-a", message);
+        verify(successCallback).run();
+        verify(failCallback, never()).run();
+    }
+
+    @Test
+    public void broadcastsWithFileIdAndRunsFailCallbackWithoutSpaceCode() {
+        FileBroadcasting<OpenAIFile> message = message("file-2", null);
+        SettableListenableFuture<SendResult<String, Object>> future = new SettableListenableFuture<>();
+        Runnable successCallback = mock(Runnable.class);
+        Runnable failCallback = mock(Runnable.class);
+        when(kafkaTemplate.send(TOPIC, "file-2", message)).thenReturn(future);
+
+        broadcastService.broadcast(message, successCallback, failCallback);
+        future.setException(new RuntimeException("send failed"));
+
+        verify(kafkaTemplate).send(TOPIC, "file-2", message);
+        verify(successCallback, never()).run();
+        verify(failCallback).run();
+    }
+
+    private FileBroadcasting<OpenAIFile> message(String fileId, String spaceCode) {
+        FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
+        message.setData(OpenAIFile.builder().id(fileId).spaceCode(spaceCode).build());
+        return message;
+    }
+}


### PR DESCRIPTION
<!-- issue-flow:source-issue=95 -->
<!-- issue-flow:source source_task_id=task-cmsy82mrn0d3k2f1rh8bsgrv5 source_runtime=agentrix -->
## Source issue

Closes #95

## Summary

- Send file lifecycle broadcasts with `space_code` as the Kafka record key when present.
- Fall back to `file_id` for files without a space so broadcasts always use a stable key.
- Keep the existing topic, message value, callbacks, and broadcast filtering behavior unchanged.
- Add configuration-level tests for both key-selection paths and success/failure callbacks.

## Validation

- `mvn -f api/pom.xml -Dtest=KafkaConfigTest,FileServiceBroadcastTest test`
- Result: 6 tests passed, 0 failures, 0 errors, 0 skipped.
