### PR TITLE
Build #98: Skip lifecycle broadcasts for system files

### DIFF
--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -100,7 +100,8 @@ public class FileService {
 
     private void broadcast(FileDB fileDB, FileBroadcasting<?> message) {
         FileType fileType = FileType.fromFileId(fileDB.getFileId());
-        if(fileType == FileType.TEMP && !FilePurpose.ASSISTANTS_CHAT.getValue().equals(fileDB.getPurpose())) {
+        if(fileType == FileType.SYSTEM
+                || (fileType == FileType.TEMP && !FilePurpose.ASSISTANTS_CHAT.getValue().equals(fileDB.getPurpose()))) {
             return;
         }
         broadcastService.broadcast(message,

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -71,6 +72,19 @@ public class FileServiceBroadcastTest {
     }
 
     @Test
+    public void finalizeUploadSkipsBroadcastForSystemFiles() {
+        for (FilePurpose purpose : new FilePurpose[] {
+                FilePurpose.PDF,
+                FilePurpose.DOM_TREE,
+                FilePurpose.DATASETS_EXPORT }) {
+            fileService.finalizeFileUpload(systemFile(purpose), "{}");
+        }
+
+        verifyNoInteractions(broadcastService);
+        verifyNoInteractions(fileRepo);
+    }
+
+    @Test
     public void updateSkipsBroadcastForNonAssistantTempFile() {
         FileDB file = tempFile(FilePurpose.VISION);
         FileOps ops = FileOps.builder().fileId(file.getFileId()).filename("updated.png").build();
@@ -94,9 +108,44 @@ public class FileServiceBroadcastTest {
         verifyNoInteractions(broadcastService);
     }
 
+    @Test
+    public void updateSkipsBroadcastForSystemFile() {
+        FileDB file = systemFile(FilePurpose.PDF);
+        FileOps ops = FileOps.builder().fileId(file.getFileId()).filename("updated.pdf").build();
+        when(fileRepo.queryFile(file.getFileId(), FileType.SYSTEM)).thenReturn(file);
+
+        fileService.updateFile(ops, false, Scope.FILENAME);
+
+        verify(fileRepo).updateFile(ops, false);
+        verify(fileRepo).queryFile(file.getFileId(), FileType.SYSTEM);
+        verifyNoMoreInteractions(fileRepo);
+        verifyNoInteractions(broadcastService);
+    }
+
+    @Test
+    public void deleteSkipsBroadcastForSystemFile() {
+        FileDB file = systemFile(FilePurpose.DATASETS_EXPORT);
+
+        fileService.delete(file);
+
+        ArgumentCaptor<FileOps> opsCaptor = ArgumentCaptor.forClass(FileOps.class);
+        verify(fileRepo).updateFile(opsCaptor.capture(), eq(false));
+        assertEquals(FileStatus.DELETED, opsCaptor.getValue().getStatus());
+        verifyNoMoreInteractions(fileRepo);
+        verifyNoInteractions(broadcastService);
+    }
+
     private FileDB tempFile(FilePurpose purpose) {
+        return file("file-test-t", purpose);
+    }
+
+    private FileDB systemFile(FilePurpose purpose) {
+        return file("file-test-s", purpose);
+    }
+
+    private FileDB file(String fileId, FilePurpose purpose) {
         FileDB file = new FileDB();
-        file.setFileId("file-test-t");
+        file.setFileId(fileId);
         file.setFilename("test.txt");
         file.setPurpose(purpose.getValue());
         file.setMetaData("{}");

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -80,8 +80,10 @@ public class FileServiceBroadcastTest {
             fileService.finalizeFileUpload(systemFile(purpose), "{}");
         }
 
+        verify(fileRepo).queryFileByPdfFileId("file-test-s");
+        verify(fileRepo).queryFileByDomTreeFileId("file-test-s");
+        verifyNoMoreInteractions(fileRepo);
         verifyNoInteractions(broadcastService);
-        verifyNoInteractions(fileRepo);
     }
 
     @Test
@@ -110,8 +112,8 @@ public class FileServiceBroadcastTest {
 
     @Test
     public void updateSkipsBroadcastForSystemFile() {
-        FileDB file = systemFile(FilePurpose.PDF);
-        FileOps ops = FileOps.builder().fileId(file.getFileId()).filename("updated.pdf").build();
+        FileDB file = systemFile(FilePurpose.DATASETS_EXPORT);
+        FileOps ops = FileOps.builder().fileId(file.getFileId()).filename("updated.json").build();
         when(fileRepo.queryFile(file.getFileId(), FileType.SYSTEM)).thenReturn(file);
 
         fileService.updateFile(ops, false, Scope.FILENAME);


### PR DESCRIPTION
<!-- issue-flow:source-issue=98 -->
<!-- issue-flow:source source_task_id=task-cmsziwdy708ob2zxh5au8e9ph source_runtime=agentrix -->
## Source issue

- #98

## Summary

- Skip file lifecycle broadcasts for `FileType.SYSTEM` in the unified `FileService.broadcast(...)` entry point.
- Return before invoking `BroadcastService`, so system files do not register or execute broadcast success/failure status callbacks.
- Preserve existing behavior for user files, directories, resource nodes, `assistants-chat` temporary files, and non-chat temporary files.
- Add coverage for system file create, update, and delete paths, while retaining the representative `assistants-chat` broadcast test.
- Account for the existing PDF and DOM tree source-file repository lookups in the system upload test; use `datasets-export` in the update test to isolate broadcast behavior.
- No deviation from the issue proposal was necessary; the current code still used the unified broadcast entry point described by the issue.

## Validation

- `git diff --check` (passed)
- `mvn -f api/pom.xml -Dtest=FileServiceBroadcastTest test` (not run: this runtime does not provide `mvn` or `java`)
