### PR TITLE
Build #102: Restore domtree file broadcasts

### DIFF
--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -149,7 +149,7 @@ public class FileService {
 
     private void broadcast(FileDB fileDB, FileBroadcasting<?> message) {
         FileType fileType = FileType.fromFileId(fileDB.getFileId());
-        if(fileType == FileType.SYSTEM
+        if((fileType == FileType.SYSTEM && !FilePurpose.DOM_TREE.getValue().equals(fileDB.getPurpose()))
                 || (fileType == FileType.TEMP && !FilePurpose.ASSISTANTS_CHAT.getValue().equals(fileDB.getPurpose()))) {
             return;
         }

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -72,18 +72,26 @@ public class FileServiceBroadcastTest {
     }
 
     @Test
-    public void finalizeUploadSkipsBroadcastForSystemFiles() {
+    public void finalizeUploadSkipsBroadcastForNonDomTreeSystemFiles() {
         for (FilePurpose purpose : new FilePurpose[] {
                 FilePurpose.PDF,
-                FilePurpose.DOM_TREE,
                 FilePurpose.DATASETS_EXPORT }) {
             fileService.finalizeFileUpload(systemFile(purpose), "{}");
         }
 
         verify(fileRepo).queryFileByPdfFileId("file-test-s");
-        verify(fileRepo).queryFileByDomTreeFileId("file-test-s");
         verifyNoMoreInteractions(fileRepo);
         verifyNoInteractions(broadcastService);
+    }
+
+    @Test
+    public void finalizeUploadBroadcastsDomTreeSystemFile() {
+        FileDB file = systemFile(FilePurpose.DOM_TREE);
+
+        fileService.finalizeFileUpload(file, "{}");
+
+        verify(fileRepo).queryFileByDomTreeFileId(file.getFileId());
+        assertBroadcastEvent(EventType.FILE_CREATED);
     }
 
     @Test
@@ -125,6 +133,20 @@ public class FileServiceBroadcastTest {
     }
 
     @Test
+    public void updateBroadcastsDomTreeSystemFile() {
+        FileDB file = systemFile(FilePurpose.DOM_TREE);
+        FileOps ops = FileOps.builder().fileId(file.getFileId()).filename("updated.json").build();
+        when(fileRepo.queryFile(file.getFileId(), FileType.SYSTEM)).thenReturn(file);
+
+        fileService.updateFile(ops, false, Scope.FILENAME);
+
+        verify(fileRepo).updateFile(ops, false);
+        verify(fileRepo).queryFile(file.getFileId(), FileType.SYSTEM);
+        verify(fileRepo).queryFileByDomTreeFileId(file.getFileId());
+        assertBroadcastEvent(EventType.FILE_UPDATED);
+    }
+
+    @Test
     public void deleteSkipsBroadcastForSystemFile() {
         FileDB file = systemFile(FilePurpose.DATASETS_EXPORT);
 
@@ -135,6 +157,25 @@ public class FileServiceBroadcastTest {
         assertEquals(FileStatus.DELETED, opsCaptor.getValue().getStatus());
         verifyNoMoreInteractions(fileRepo);
         verifyNoInteractions(broadcastService);
+    }
+
+    @Test
+    public void deleteBroadcastsDomTreeSystemFile() {
+        FileDB file = systemFile(FilePurpose.DOM_TREE);
+
+        fileService.delete(file);
+
+        ArgumentCaptor<FileOps> opsCaptor = ArgumentCaptor.forClass(FileOps.class);
+        verify(fileRepo).updateFile(opsCaptor.capture(), eq(false));
+        assertEquals(FileStatus.DELETED, opsCaptor.getValue().getStatus());
+        verify(fileRepo).queryFileByDomTreeFileId(file.getFileId());
+        assertBroadcastEvent(EventType.FILE_DELETED);
+    }
+
+    private void assertBroadcastEvent(EventType eventType) {
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(eventType.getValue(), messageCaptor.getValue().getEvent());
     }
 
     private FileDB tempFile(FilePurpose purpose) {


### PR DESCRIPTION
<!-- issue-flow:source-issue=102 -->
<!-- issue-flow:source source_task_id=task-cmt703umn0m6g2zxhc0vi8bx0 source_runtime=agentrix -->
## Source issue

- #102

## Summary

- Allow `FileType.SYSTEM` files with purpose `dom_tree` to continue through `FileService.broadcast`.
- Keep broadcast suppression unchanged for other system-file purposes and non-assistant temporary files.
- Add positive coverage for domtree `FILE_CREATED`, `FILE_UPDATED`, and `FILE_DELETED` events, plus negative coverage for PDF and datasets-export system files.

## Validation

- `git diff --check` — passed.
- `mvn -Dtest=FileServiceBroadcastTest test` — not run because this runtime does not provide Java or Maven (`mvn: command not found`).
