### PR TITLE
Build #106: 支持单独更新 file metadata

### DIFF
--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -66,6 +66,7 @@ import com.ke.bella.files.protocol.Progress;
 import com.ke.bella.files.protocol.Scope;
 import com.ke.bella.files.protocol.UpdateCitiesOps;
 import com.ke.bella.files.protocol.UpdateDescriptionOps;
+import com.ke.bella.files.protocol.UpdateMetadataOps;
 import com.ke.bella.files.protocol.UpdateProgressRequestData;
 import com.ke.bella.files.protocol.UpdateTagsOps;
 import com.ke.bella.files.service.FileService;
@@ -1286,6 +1287,27 @@ public class FileController {
                 .build();
 
         return fileService.updateFile(ops, false, Scope.DESCRIPTION);
+    }
+
+    @PutMapping("/{fileId}/metadata")
+    public OpenAIFile updateMetadata(
+            @PathVariable String fileId,
+            @RequestBody UpdateMetadataOps op) {
+        Assert.hasText(fileId, "file_id is required");
+        Assert.notNull(op, "invalid request body");
+        Assert.notNull(op.getMetadata(), "metadata is required");
+
+        OpenAIFile existingFile = fileService.getFile(fileId);
+        if(existingFile == null) {
+            throw new FileNotFoundException(fileId);
+        }
+
+        FileOps ops = FileOps.builder()
+                .fileId(fileId)
+                .metadata(op.getMetadata())
+                .build();
+
+        return fileService.updateFile(ops, false, Scope.METADATA);
     }
 
     /**

--- a/api/src/main/java/com/ke/bella/files/protocol/Scope.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/Scope.java
@@ -11,6 +11,7 @@ public enum Scope {
     DOM_TREE("dom_tree"),
     PDF("pdf"),
     DESCRIPTION("description"),
+    METADATA("metadata"),
     CITIES("cities"),
     TAGS("tags"),
     LOCATION("location");

--- a/api/src/main/java/com/ke/bella/files/protocol/UpdateMetadataOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/UpdateMetadataOps.java
@@ -1,0 +1,13 @@
+package com.ke.bella.files.protocol;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateMetadataOps {
+
+    private String metadata;
+}

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerUpdateMetadataTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerUpdateMetadataTest.java
@@ -1,0 +1,117 @@
+package com.ke.bella.files.api;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
+import com.ke.bella.files.protocol.FileOps;
+import com.ke.bella.files.protocol.OpenAIFile;
+import com.ke.bella.files.protocol.Scope;
+import com.ke.bella.files.service.FileService;
+import com.ke.bella.files.service.lock.FileUniquenessLock;
+
+public class FileControllerUpdateMetadataTest {
+
+    private MockMvc mockMvc;
+    private FileService fileService;
+
+    @Before
+    public void setup() {
+        fileService = Mockito.mock(FileService.class);
+        FileController fileController = new FileController();
+        ReflectionTestUtils.setField(fileController, "fileService", fileService);
+        ReflectionTestUtils.setField(fileController, "fl", Mockito.mock(FileUniquenessLock.class));
+        mockMvc = MockMvcBuilders.standaloneSetup(fileController)
+                .setControllerAdvice(new FileApiResponseAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(new ObjectMapper()))
+                .build();
+    }
+
+    @Test
+    public void updateMetadata_FileSuccess() throws Exception {
+        assertSuccessfulUpdate("file-test-u", "file", false);
+    }
+
+    @Test
+    public void updateMetadata_DirectorySuccess() throws Exception {
+        assertSuccessfulUpdate("file-directory-u", "directory", true);
+    }
+
+    @Test
+    public void updateMetadata_MissingMetadata() throws Exception {
+        mockMvc.perform(put("/v1/files/{fileId}/metadata", "file-test-u")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value("metadata is required"));
+
+        verify(fileService, never()).getFile("file-test-u");
+    }
+
+    @Test
+    public void updateMetadata_FileNotFound() throws Exception {
+        when(fileService.getFile("file-missing-u")).thenReturn(null);
+
+        mockMvc.perform(put("/v1/files/{fileId}/metadata", "file-missing-u")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"metadata\":\"{\\\"team\\\":\\\"search\\\"}\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.message").exists());
+
+        verify(fileService).getFile("file-missing-u");
+        verify(fileService, never()).updateFile(Mockito.any(FileOps.class), eq(false), eq(Scope.METADATA));
+    }
+
+    private void assertSuccessfulUpdate(String fileId, String nodeType, boolean directory) throws Exception {
+        String oldMetadata = "{\"team\":\"old\"}";
+        String newMetadata = "{\"team\":\"search\"}";
+        OpenAIFile existingFile = OpenAIFile.builder()
+                .id(fileId)
+                .filename("test.txt")
+                .metadata(oldMetadata)
+                .nodeType(nodeType)
+                .isDir(directory)
+                .description("unchanged")
+                .version(7L)
+                .build();
+        OpenAIFile updatedFile = existingFile.toBuilder().metadata(newMetadata).build();
+        when(fileService.getFile(fileId)).thenReturn(existingFile);
+        when(fileService.updateFile(argThat(op -> fileId.equals(op.getFileId())
+                && newMetadata.equals(op.getMetadata())
+                && op.getFilename() == null
+                && op.getDescription() == null
+                && op.getCities() == null
+                && op.getTags() == null), eq(false), eq(Scope.METADATA)))
+                        .thenReturn(updatedFile);
+
+        mockMvc.perform(put("/v1/files/{fileId}/metadata", fileId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"metadata\":\"{\\\"team\\\":\\\"search\\\"}\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(fileId))
+                .andExpect(jsonPath("$.metadata").value(newMetadata))
+                .andExpect(jsonPath("$.filename").value("test.txt"))
+                .andExpect(jsonPath("$.description").value("unchanged"))
+                .andExpect(jsonPath("$.version").value(7));
+
+        verify(fileService).getFile(fileId);
+        verify(fileService).updateFile(argThat(op -> fileId.equals(op.getFileId())
+                && newMetadata.equals(op.getMetadata())), eq(false), eq(Scope.METADATA));
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoUpdateTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoUpdateTransactionTest.java
@@ -103,6 +103,21 @@ public class FileRepoUpdateTransactionTest {
     }
 
     @Test
+    public void metadataUpdateLeavesOtherFileFieldsUntouched() {
+        FileDB before = queryFile(SOURCE);
+
+        fileRepo.updateFile(FileOps.builder().fileId(SOURCE).metadata("{\"team\":\"search\"}").build(), false);
+
+        FileDB after = queryFile(SOURCE);
+        assertEquals("{\"team\":\"search\"}", after.getMetaData());
+        assertEquals(before.getFilename(), after.getFilename());
+        assertEquals(before.getPurpose(), after.getPurpose());
+        assertEquals(before.getStatus(), after.getStatus());
+        assertEquals(before.getVersion(), after.getVersion());
+        assertEquals(queryEntryFilename(SOURCE), after.getFilename());
+    }
+
+    @Test
     public void deleteHardDeletesEntry() {
         fileRepo.updateFile(FileOps.builder().fileId(SOURCE).status(FileStatus.DELETED).build());
 

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -147,6 +147,22 @@ public class FileServiceBroadcastTest {
     }
 
     @Test
+    public void metadataUpdateBroadcastsMetadataScope() {
+        FileDB file = file("file-test-u", FilePurpose.ASSISTANTS);
+        file.setMetaData("{\"team\":\"search\"}");
+        FileOps ops = FileOps.builder().fileId(file.getFileId()).metadata(file.getMetaData()).build();
+        when(fileRepo.queryFile(file.getFileId(), FileType.USER)).thenReturn(file);
+
+        fileService.updateFile(ops, false, Scope.METADATA);
+
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_UPDATED.getValue(), messageCaptor.getValue().getEvent());
+        assertEquals(Scope.METADATA.getValue(), messageCaptor.getValue().getScope());
+        assertEquals(file.getMetaData(), messageCaptor.getValue().getMetadata());
+    }
+
+    @Test
     public void deleteSkipsBroadcastForSystemFile() {
         FileDB file = systemFile(FilePurpose.DATASETS_EXPORT);
 


### PR DESCRIPTION
<!-- issue-flow:source-issue=106 -->
<!-- issue-flow:source source_task_id=task-cmt84vrmh0nty2zxh0onzgvmn source_runtime=agentrix -->
## Source issue

- #106 支持单独更新 file 的 metadata

## Summary

- 新增 `PUT /v1/files/{fileId}/metadata`，请求体仅需提供 `metadata`。
- 复用现有文件查询、鉴权与更新链路，文件不存在时保持既有 404 处理。
- metadata 更新不递增内容版本，也不修改文件内容、文件名、description、cities 或 tags。
- 新增 `metadata` 更新事件 scope，继续发送既有 `FILE_UPDATED` 事件。
- 普通文件和目录均支持该接口；未偏离 issue 方案。

## Validation

- `git diff --check`（通过）
- 新增 Controller 测试：普通文件成功、目录成功、缺少 metadata、文件不存在。
- 新增 Repo 测试：仅 metadata 发生变化，其他字段及版本保持不变。
- 新增 Service 测试：更新事件为 `FILE_UPDATED` 且 `scope=metadata`。
- 未运行 JUnit：当前执行环境未安装 Java 和 Maven（`java: command not found`、`mvn: command not found`）。
