### PR TITLE
Build #107: 支持更新文件创建人信息

### DIFF
--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -1395,20 +1395,29 @@ public class FileController {
             @RequestBody UpdateCreatorOps op) {
         Assert.hasText(fileId, "file_id is required");
         Assert.notNull(op, "invalid request body");
-        Assert.notNull(op.getCuid(), "cuid is required");
-        Assert.isTrue(op.getCuid() >= 0, "cuid must not be negative");
-        Assert.hasText(op.getCuName(), "cu_name is required");
-        Assert.isTrue(op.getCuName().length() <= MAX_CREATOR_NAME_LENGTH,
-                "cu_name cannot exceed 32 characters");
-        Assert.notNull(op.getCreatedAt(), "created_at is required");
-        Assert.isTrue(op.getCreatedAt() >= 0, "created_at must not be negative");
+        Assert.isTrue(op.hasAnyField(), "at least one creator field is required");
+        if(op.isCuidSet()) {
+            Assert.notNull(op.getCuid(), "cuid must not be null");
+            Assert.isTrue(op.getCuid() >= 0, "cuid must not be negative");
+        }
+        if(op.isCuNameSet()) {
+            Assert.hasText(op.getCuName(), "cu_name must not be blank");
+            Assert.isTrue(op.getCuName().length() <= MAX_CREATOR_NAME_LENGTH,
+                    "cu_name cannot exceed 32 characters");
+        }
+        LocalDateTime ctime = null;
+        if(op.isCreatedAtSet()) {
+            Assert.notNull(op.getCreatedAt(), "created_at must not be null");
+            Assert.isTrue(op.getCreatedAt() >= 0, "created_at must not be negative");
+            ctime = toLocalDateTime(op.getCreatedAt());
+        }
 
         OpenAIFile existingFile = fileService.getFile(fileId);
         if(existingFile == null) {
             throw new FileNotFoundException(fileId);
         }
 
-        return fileService.updateCreatorInfo(fileId, op.getCuid(), op.getCuName(), toLocalDateTime(op.getCreatedAt()));
+        return fileService.updateCreatorInfo(fileId, op.getCuid(), op.getCuName(), ctime);
     }
 
     private LocalDateTime toLocalDateTime(Long timestamp) {

--- a/api/src/main/java/com/ke/bella/files/api/FileController.java
+++ b/api/src/main/java/com/ke/bella/files/api/FileController.java
@@ -9,6 +9,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +69,7 @@ import com.ke.bella.files.protocol.PageFileOps;
 import com.ke.bella.files.protocol.Progress;
 import com.ke.bella.files.protocol.Scope;
 import com.ke.bella.files.protocol.UpdateCitiesOps;
+import com.ke.bella.files.protocol.UpdateCreatorOps;
 import com.ke.bella.files.protocol.UpdateDescriptionOps;
 import com.ke.bella.files.protocol.UpdateMetadataOps;
 import com.ke.bella.files.protocol.UpdateProgressRequestData;
@@ -98,6 +103,8 @@ public class FileController {
     private static final int MAX_CITIES_JSON_LENGTH = 512;
 
     private static final int MAX_TAGS_JSON_LENGTH = 512;
+
+    private static final int MAX_CREATOR_NAME_LENGTH = 32;
 
     private static final Pattern WINDOWS_INVALID_CHARS = Pattern.compile("[<>:\"|?*\\\\]|[\\x00-\\x1f]");
 
@@ -1380,6 +1387,38 @@ public class FileController {
                 .build();
 
         return fileService.updateFile(ops, true, Scope.TAGS);
+    }
+
+    @PutMapping("/{fileId}/creator")
+    public OpenAIFile updateCreator(
+            @PathVariable String fileId,
+            @RequestBody UpdateCreatorOps op) {
+        Assert.hasText(fileId, "file_id is required");
+        Assert.notNull(op, "invalid request body");
+        Assert.notNull(op.getCuid(), "cuid is required");
+        Assert.isTrue(op.getCuid() >= 0, "cuid must not be negative");
+        Assert.hasText(op.getCuName(), "cu_name is required");
+        Assert.isTrue(op.getCuName().length() <= MAX_CREATOR_NAME_LENGTH,
+                "cu_name cannot exceed 32 characters");
+        Assert.notNull(op.getCreatedAt(), "created_at is required");
+        Assert.isTrue(op.getCreatedAt() >= 0, "created_at must not be negative");
+
+        OpenAIFile existingFile = fileService.getFile(fileId);
+        if(existingFile == null) {
+            throw new FileNotFoundException(fileId);
+        }
+
+        return fileService.updateCreatorInfo(fileId, op.getCuid(), op.getCuName(), toLocalDateTime(op.getCreatedAt()));
+    }
+
+    private LocalDateTime toLocalDateTime(Long timestamp) {
+        try {
+            LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+            Assert.isTrue(dateTime.getYear() <= 9999, "created_at is out of range");
+            return dateTime;
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException("created_at is out of range", e);
+        }
     }
 
     @GetMapping("/exists")

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -344,6 +344,22 @@ public class FileRepo implements BaseRepo {
         updateFile(op, false);
     }
 
+    @Transactional(rollbackFor = Exception.class)
+    public void updateCreatorInfo(String fileId, Long cuid, String cuName, LocalDateTime ctime) {
+        fileId = queryNewFileId(fileId);
+        String shardingKey = getShardingKeyByFileId(fileId);
+        int updatedNum = db(shardingKey).update(FILE)
+                .set(FILE.CUID, cuid)
+                .set(FILE.CU_NAME, cuName)
+                .set(FILE.CTIME, ctime)
+                .where(FILE.FILE_ID.eq(fileId))
+                .execute();
+
+        if(updatedNum != 1) {
+            throw new IllegalStateException("update file creator failed, fileId: " + fileId);
+        }
+    }
+
     public List<FileDB> listFile(
             String purpose,
             Integer limit,

--- a/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
+++ b/api/src/main/java/com/ke/bella/files/db/repo/FileRepo.java
@@ -346,12 +346,21 @@ public class FileRepo implements BaseRepo {
 
     @Transactional(rollbackFor = Exception.class)
     public void updateCreatorInfo(String fileId, Long cuid, String cuName, LocalDateTime ctime) {
+        Map<Field<?>, Object> values = new HashMap<>();
+        if(cuid != null) {
+            values.put(FILE.CUID, cuid);
+        }
+        if(cuName != null) {
+            values.put(FILE.CU_NAME, cuName);
+        }
+        if(ctime != null) {
+            values.put(FILE.CTIME, ctime);
+        }
+        Assert.notEmpty(values, "at least one creator field is required");
         fileId = queryNewFileId(fileId);
         String shardingKey = getShardingKeyByFileId(fileId);
         int updatedNum = db(shardingKey).update(FILE)
-                .set(FILE.CUID, cuid)
-                .set(FILE.CU_NAME, cuName)
-                .set(FILE.CTIME, ctime)
+                .set(values)
                 .where(FILE.FILE_ID.eq(fileId))
                 .execute();
 

--- a/api/src/main/java/com/ke/bella/files/protocol/Scope.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/Scope.java
@@ -14,6 +14,7 @@ public enum Scope {
     METADATA("metadata"),
     CITIES("cities"),
     TAGS("tags"),
+    CREATOR("creator"),
     LOCATION("location");
 
     private final String value;

--- a/api/src/main/java/com/ke/bella/files/protocol/UpdateCreatorOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/UpdateCreatorOps.java
@@ -1,19 +1,46 @@
 package com.ke.bella.files.protocol;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class UpdateCreatorOps {
 
     private Long cuid;
-    @JsonProperty("cu_name")
     private String cuName;
-    @JsonProperty("created_at")
     private Long createdAt;
+
+    @JsonIgnore
+    private boolean cuidSet;
+    @JsonIgnore
+    private boolean cuNameSet;
+    @JsonIgnore
+    private boolean createdAtSet;
+
+    @JsonSetter("cuid")
+    public void setCuid(Long cuid) {
+        this.cuid = cuid;
+        this.cuidSet = true;
+    }
+
+    @JsonSetter("cu_name")
+    public void setCuName(String cuName) {
+        this.cuName = cuName;
+        this.cuNameSet = true;
+    }
+
+    @JsonSetter("created_at")
+    public void setCreatedAt(Long createdAt) {
+        this.createdAt = createdAt;
+        this.createdAtSet = true;
+    }
+
+    @JsonIgnore
+    public boolean hasAnyField() {
+        return cuidSet || cuNameSet || createdAtSet;
+    }
 }

--- a/api/src/main/java/com/ke/bella/files/protocol/UpdateCreatorOps.java
+++ b/api/src/main/java/com/ke/bella/files/protocol/UpdateCreatorOps.java
@@ -1,0 +1,19 @@
+package com.ke.bella.files.protocol;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateCreatorOps {
+
+    private Long cuid;
+    @JsonProperty("cu_name")
+    private String cuName;
+    @JsonProperty("created_at")
+    private Long createdAt;
+}

--- a/api/src/main/java/com/ke/bella/files/service/FileService.java
+++ b/api/src/main/java/com/ke/bella/files/service/FileService.java
@@ -4,6 +4,7 @@ import static com.ke.bella.files.db.IDGenerator.FILE_ID_GENERATOR;
 
 import java.io.File;
 import java.io.InputStream;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -560,11 +561,23 @@ public class FileService {
         FileType fileType = FileType.fromFileId(ops.getFileId());
         fileRepo.updateFile(ops, increaseVersion);
         FileDB fileDB = fileRepo.queryFile(ops.getFileId(), fileType);
+        return broadcastFileUpdated(fileDB, actionType);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public OpenAIFile updateCreatorInfo(String fileId, Long cuid, String cuName, LocalDateTime ctime) {
+        FileType fileType = FileType.fromFileId(fileId);
+        fileRepo.updateCreatorInfo(fileId, cuid, cuName, ctime);
+        FileDB fileDB = fileRepo.queryFile(fileId, fileType);
+        return broadcastFileUpdated(fileDB, Scope.CREATOR);
+    }
+
+    private OpenAIFile broadcastFileUpdated(FileDB fileDB, Scope scope) {
         OpenAIFile finalOpenAIFile = buildOpenAIFileWithSource(fileDB);
 
         FileBroadcasting<OpenAIFile> message = new FileBroadcasting<>();
         message.setEvent(EventType.FILE_UPDATED);
-        message.setScope(actionType.getValue());
+        message.setScope(scope.getValue());
         message.setData(finalOpenAIFile);
         message.setMetadata(fileDB.getMetaData());
         message.setUserId(BellaContextHelper.getOperatorUserId());

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerUpdateCreatorTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerUpdateCreatorTest.java
@@ -1,0 +1,115 @@
+package com.ke.bella.files.api;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.ke.bella.files.api.interceptor.FileApiResponseAdvice;
+import com.ke.bella.files.protocol.OpenAIFile;
+import com.ke.bella.files.service.FileService;
+import com.ke.bella.files.service.lock.FileUniquenessLock;
+
+public class FileControllerUpdateCreatorTest {
+    private static final String FILE_ID = "file-test-1";
+    private static final long CREATED_AT = 1704067200000L;
+
+    private MockMvc mockMvc;
+    private FileService fileService;
+
+    @Before
+    public void setup() {
+        fileService = Mockito.mock(FileService.class);
+        FileController fileController = new FileController();
+        ReflectionTestUtils.setField(fileController, "fileService", fileService);
+        ReflectionTestUtils.setField(fileController, "fl", Mockito.mock(FileUniquenessLock.class));
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        mockMvc = MockMvcBuilders.standaloneSetup(fileController)
+                .setControllerAdvice(new FileApiResponseAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    public void updateCreatorSuccess() throws Exception {
+        OpenAIFile existing = OpenAIFile.builder().id(FILE_ID).filename("test.txt").version(3L).build();
+        OpenAIFile updated = existing.toBuilder().cuid(42L).cuName("original creator").createdAt(CREATED_AT).build();
+        LocalDateTime ctime = LocalDateTime.ofInstant(Instant.ofEpochMilli(CREATED_AT), ZoneId.systemDefault());
+        when(fileService.getFile(FILE_ID)).thenReturn(existing);
+        when(fileService.updateCreatorInfo(FILE_ID, 42L, "original creator", ctime)).thenReturn(updated);
+
+        mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cuid\":42,\"cu_name\":\"original creator\",\"created_at\":" + CREATED_AT + "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(FILE_ID))
+                .andExpect(jsonPath("$.cuid").value(42L))
+                .andExpect(jsonPath("$.cu_name").value("original creator"))
+                .andExpect(jsonPath("$.created_at").value(CREATED_AT))
+                .andExpect(jsonPath("$.version").value(3L));
+
+        verify(fileService).updateCreatorInfo(FILE_ID, 42L, "original creator", ctime);
+    }
+
+    @Test
+    public void updateCreatorFileNotFound() throws Exception {
+        when(fileService.getFile(FILE_ID)).thenReturn(null);
+
+        mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cuid\":42,\"cu_name\":\"creator\",\"created_at\":" + CREATED_AT + "}"))
+                .andExpect(status().isNotFound());
+
+        verify(fileService, never()).updateCreatorInfo(eq(FILE_ID), eq(42L), eq("creator"), Mockito.any(LocalDateTime.class));
+    }
+
+    @Test
+    public void updateCreatorRejectsMissingBody() throws Exception {
+        mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        verify(fileService, never()).getFile(FILE_ID);
+    }
+
+    @Test
+    public void updateCreatorRejectsInvalidFieldsWithoutPartialUpdate() throws Exception {
+        String[] invalidBodies = {
+                "{\"cu_name\":\"creator\",\"created_at\":" + CREATED_AT + "}",
+                "{\"cuid\":-1,\"cu_name\":\"creator\",\"created_at\":" + CREATED_AT + "}",
+                "{\"cuid\":42,\"cu_name\":\" \",\"created_at\":" + CREATED_AT + "}",
+                "{\"cuid\":42,\"cu_name\":\"creator\"}",
+                "{\"cuid\":42,\"cu_name\":\"creator\",\"created_at\":-1}"
+        };
+
+        for (String body : invalidBodies) {
+            mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        verify(fileService, never()).getFile(FILE_ID);
+        verify(fileService, never()).updateCreatorInfo(
+                Mockito.anyString(), Mockito.anyLong(), Mockito.anyString(), Mockito.any(LocalDateTime.class));
+    }
+}

--- a/api/src/test/java/com/ke/bella/files/api/FileControllerUpdateCreatorTest.java
+++ b/api/src/test/java/com/ke/bella/files/api/FileControllerUpdateCreatorTest.java
@@ -71,6 +71,62 @@ public class FileControllerUpdateCreatorTest {
     }
 
     @Test
+    public void updateCreatorSupportsUpdatingCuidOnly() throws Exception {
+        OpenAIFile existing = OpenAIFile.builder().id(FILE_ID).cuid(1L).cuName("creator").createdAt(CREATED_AT).build();
+        OpenAIFile updated = existing.toBuilder().cuid(42L).build();
+        when(fileService.getFile(FILE_ID)).thenReturn(existing);
+        when(fileService.updateCreatorInfo(FILE_ID, 42L, null, null)).thenReturn(updated);
+
+        mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cuid\":42}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cuid").value(42L))
+                .andExpect(jsonPath("$.cu_name").value("creator"))
+                .andExpect(jsonPath("$.created_at").value(CREATED_AT));
+
+        verify(fileService).updateCreatorInfo(FILE_ID, 42L, null, null);
+    }
+
+    @Test
+    public void updateCreatorSupportsUpdatingNameOnly() throws Exception {
+        OpenAIFile existing = OpenAIFile.builder().id(FILE_ID).cuid(1L).cuName("old creator").createdAt(CREATED_AT).build();
+        OpenAIFile updated = existing.toBuilder().cuName("new creator").build();
+        when(fileService.getFile(FILE_ID)).thenReturn(existing);
+        when(fileService.updateCreatorInfo(FILE_ID, null, "new creator", null)).thenReturn(updated);
+
+        mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cu_name\":\"new creator\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cuid").value(1L))
+                .andExpect(jsonPath("$.cu_name").value("new creator"))
+                .andExpect(jsonPath("$.created_at").value(CREATED_AT));
+
+        verify(fileService).updateCreatorInfo(FILE_ID, null, "new creator", null);
+    }
+
+    @Test
+    public void updateCreatorSupportsUpdatingCreatedAtOnly() throws Exception {
+        long updatedCreatedAt = CREATED_AT + 1000;
+        LocalDateTime ctime = LocalDateTime.ofInstant(Instant.ofEpochMilli(updatedCreatedAt), ZoneId.systemDefault());
+        OpenAIFile existing = OpenAIFile.builder().id(FILE_ID).cuid(1L).cuName("creator").createdAt(CREATED_AT).build();
+        OpenAIFile updated = existing.toBuilder().createdAt(updatedCreatedAt).build();
+        when(fileService.getFile(FILE_ID)).thenReturn(existing);
+        when(fileService.updateCreatorInfo(FILE_ID, null, null, ctime)).thenReturn(updated);
+
+        mockMvc.perform(put("/v1/files/{fileId}/creator", FILE_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"created_at\":" + updatedCreatedAt + "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cuid").value(1L))
+                .andExpect(jsonPath("$.cu_name").value("creator"))
+                .andExpect(jsonPath("$.created_at").value(updatedCreatedAt));
+
+        verify(fileService).updateCreatorInfo(FILE_ID, null, null, ctime);
+    }
+
+    @Test
     public void updateCreatorFileNotFound() throws Exception {
         when(fileService.getFile(FILE_ID)).thenReturn(null);
 
@@ -94,11 +150,13 @@ public class FileControllerUpdateCreatorTest {
     @Test
     public void updateCreatorRejectsInvalidFieldsWithoutPartialUpdate() throws Exception {
         String[] invalidBodies = {
-                "{\"cu_name\":\"creator\",\"created_at\":" + CREATED_AT + "}",
-                "{\"cuid\":-1,\"cu_name\":\"creator\",\"created_at\":" + CREATED_AT + "}",
-                "{\"cuid\":42,\"cu_name\":\" \",\"created_at\":" + CREATED_AT + "}",
-                "{\"cuid\":42,\"cu_name\":\"creator\"}",
-                "{\"cuid\":42,\"cu_name\":\"creator\",\"created_at\":-1}"
+                "{}",
+                "{\"cuid\":null}",
+                "{\"cuid\":-1}",
+                "{\"cu_name\":null}",
+                "{\"cu_name\":\" \"}",
+                "{\"created_at\":null}",
+                "{\"created_at\":-1}"
         };
 
         for (String body : invalidBodies) {
@@ -110,6 +168,6 @@ public class FileControllerUpdateCreatorTest {
 
         verify(fileService, never()).getFile(FILE_ID);
         verify(fileService, never()).updateCreatorInfo(
-                Mockito.anyString(), Mockito.anyLong(), Mockito.anyString(), Mockito.any(LocalDateTime.class));
+                Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 }

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoUpdateTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoUpdateTransactionTest.java
@@ -173,6 +173,51 @@ public class FileRepoUpdateTransactionTest {
         assertEquals(before.getMtime(), after.getMtime());
     }
 
+    @Test
+    public void updateCreatorInfoSupportsIndividualFields() {
+        FileDB original = queryFile(SOURCE);
+
+        fileRepo.updateCreatorInfo(SOURCE, 42L, null, null);
+        FileDB afterCuid = queryFile(SOURCE);
+        assertEquals(Long.valueOf(42L), afterCuid.getCuid());
+        assertEquals(original.getCuName(), afterCuid.getCuName());
+        assertEquals(original.getCtime(), afterCuid.getCtime());
+
+        fileRepo.updateCreatorInfo(SOURCE, null, "new creator", null);
+        FileDB afterName = queryFile(SOURCE);
+        assertEquals(Long.valueOf(42L), afterName.getCuid());
+        assertEquals("new creator", afterName.getCuName());
+        assertEquals(original.getCtime(), afterName.getCtime());
+
+        LocalDateTime updatedCtime = LocalDateTime.of(2024, 1, 2, 3, 4, 5);
+        fileRepo.updateCreatorInfo(SOURCE, null, null, updatedCtime);
+        FileDB afterCtime = queryFile(SOURCE);
+        assertEquals(Long.valueOf(42L), afterCtime.getCuid());
+        assertEquals("new creator", afterCtime.getCuName());
+        assertEquals(updatedCtime, afterCtime.getCtime());
+        assertEquals(original.getVersion(), afterCtime.getVersion());
+        assertEquals(original.getFilename(), afterCtime.getFilename());
+        assertEquals(original.getMetaData(), afterCtime.getMetaData());
+        assertEquals(original.getMtime(), afterCtime.getMtime());
+    }
+
+    @Test
+    public void updateCreatorInfoRejectsEmptyUpdate() {
+        FileDB before = queryFile(SOURCE);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> fileRepo.updateCreatorInfo(SOURCE, null, null, null));
+
+        FileDB after = queryFile(SOURCE);
+        assertEquals(before.getCuid(), after.getCuid());
+        assertEquals(before.getCuName(), after.getCuName());
+        assertEquals(before.getCtime(), after.getCtime());
+        assertEquals(before.getVersion(), after.getVersion());
+        assertEquals(before.getFilename(), after.getFilename());
+        assertEquals(before.getMetaData(), after.getMetaData());
+        assertEquals(before.getMtime(), after.getMtime());
+    }
+
     private void addFile(String fileId, String filename) {
         FileDB file = new FileDB();
         file.setFileId(fileId);

--- a/api/src/test/java/com/ke/bella/files/db/repo/FileRepoUpdateTransactionTest.java
+++ b/api/src/test/java/com/ke/bella/files/db/repo/FileRepoUpdateTransactionTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
+import java.time.LocalDateTime;
+
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcDataSource;
@@ -146,6 +148,29 @@ public class FileRepoUpdateTransactionTest {
                 .set(FILE_ENTRY.FILENAME, "duplicate-file.txt")
                 .set(FILE_ENTRY.TYPE, FileEntryRepo.TYPE_FILE)
                 .execute());
+    }
+
+    @Test
+    public void updateCreatorInfoOnlyChangesCreatorAuditFields() {
+        FileDB before = queryFile(SOURCE);
+        LocalDateTime originalCtime = LocalDateTime.of(2024, 1, 2, 3, 4, 5);
+
+        fileRepo.updateCreatorInfo(SOURCE, 42L, "original creator", originalCtime);
+
+        FileDB after = queryFile(SOURCE);
+        assertEquals(Long.valueOf(42L), after.getCuid());
+        assertEquals("original creator", after.getCuName());
+        assertEquals(originalCtime, after.getCtime());
+        assertEquals(before.getVersion(), after.getVersion());
+        assertEquals(before.getFilename(), after.getFilename());
+        assertEquals(before.getPurpose(), after.getPurpose());
+        assertEquals(before.getMetaData(), after.getMetaData());
+        assertEquals(before.getDescription(), after.getDescription());
+        assertEquals(before.getCities(), after.getCities());
+        assertEquals(before.getTags(), after.getTags());
+        assertEquals(before.getMuid(), after.getMuid());
+        assertEquals(before.getMuName(), after.getMuName());
+        assertEquals(before.getMtime(), after.getMtime());
     }
 
     private void addFile(String fileId, String filename) {

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -147,6 +147,7 @@ public class FileServiceBroadcastTest {
     }
 
     @Test
+<<<<<<< HEAD
     public void metadataUpdateBroadcastsMetadataScope() {
         FileDB file = file("file-test-u", FilePurpose.ASSISTANTS);
         file.setMetaData("{\"team\":\"search\"}");
@@ -160,6 +161,24 @@ public class FileServiceBroadcastTest {
         assertEquals(EventType.FILE_UPDATED.getValue(), messageCaptor.getValue().getEvent());
         assertEquals(Scope.METADATA.getValue(), messageCaptor.getValue().getScope());
         assertEquals(file.getMetaData(), messageCaptor.getValue().getMetadata());
+=======
+    public void updateCreatorBroadcastsDedicatedScope() {
+        FileDB file = file("file-test-1", FilePurpose.ASSISTANTS);
+        LocalDateTime ctime = LocalDateTime.of(2024, 1, 2, 3, 4, 5);
+        file.setCuid(42L);
+        file.setCuName("original creator");
+        file.setCtime(ctime);
+        when(fileRepo.queryFile(file.getFileId(), FileType.USER)).thenReturn(file);
+
+        fileService.updateCreatorInfo(file.getFileId(), 42L, "original creator", ctime);
+
+        verify(fileRepo).updateCreatorInfo(file.getFileId(), 42L, "original creator", ctime);
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(EventType.FILE_UPDATED.getValue(), messageCaptor.getValue().getEvent());
+        assertEquals(Scope.CREATOR.getValue(), messageCaptor.getValue().getScope());
+        assertEquals(Long.valueOf(42L), ((com.ke.bella.files.protocol.OpenAIFile) messageCaptor.getValue().getData()).getCuid());
+>>>>>>> 6ccca07 (feat: support updating file creator info)
     }
 
     @Test

--- a/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
+++ b/api/src/test/java/com/ke/bella/files/service/FileServiceBroadcastTest.java
@@ -147,7 +147,6 @@ public class FileServiceBroadcastTest {
     }
 
     @Test
-<<<<<<< HEAD
     public void metadataUpdateBroadcastsMetadataScope() {
         FileDB file = file("file-test-u", FilePurpose.ASSISTANTS);
         file.setMetaData("{\"team\":\"search\"}");
@@ -161,7 +160,9 @@ public class FileServiceBroadcastTest {
         assertEquals(EventType.FILE_UPDATED.getValue(), messageCaptor.getValue().getEvent());
         assertEquals(Scope.METADATA.getValue(), messageCaptor.getValue().getScope());
         assertEquals(file.getMetaData(), messageCaptor.getValue().getMetadata());
-=======
+    }
+
+    @Test
     public void updateCreatorBroadcastsDedicatedScope() {
         FileDB file = file("file-test-1", FilePurpose.ASSISTANTS);
         LocalDateTime ctime = LocalDateTime.of(2024, 1, 2, 3, 4, 5);
@@ -178,7 +179,21 @@ public class FileServiceBroadcastTest {
         assertEquals(EventType.FILE_UPDATED.getValue(), messageCaptor.getValue().getEvent());
         assertEquals(Scope.CREATOR.getValue(), messageCaptor.getValue().getScope());
         assertEquals(Long.valueOf(42L), ((com.ke.bella.files.protocol.OpenAIFile) messageCaptor.getValue().getData()).getCuid());
->>>>>>> 6ccca07 (feat: support updating file creator info)
+    }
+
+    @Test
+    public void updateCreatorBroadcastsWhenUpdatingSingleField() {
+        FileDB file = file("file-test-1", FilePurpose.ASSISTANTS);
+        file.setCuid(42L);
+        file.setCuName("creator");
+        when(fileRepo.queryFile(file.getFileId(), FileType.USER)).thenReturn(file);
+
+        fileService.updateCreatorInfo(file.getFileId(), 42L, null, null);
+
+        verify(fileRepo).updateCreatorInfo(file.getFileId(), 42L, null, null);
+        ArgumentCaptor<FileBroadcasting> messageCaptor = ArgumentCaptor.forClass(FileBroadcasting.class);
+        verify(broadcastService).broadcast(messageCaptor.capture(), any(Runnable.class), any(Runnable.class));
+        assertEquals(Scope.CREATOR.getValue(), messageCaptor.getValue().getScope());
     }
 
     @Test


### PR DESCRIPTION
<!-- issue-flow:source-issue=107 -->
<!-- issue-flow:source source_task_id=task-cmt84sqrf0nry2zxhdnu2a8bb source_runtime=agentrix -->
## Source issue

- #107

## Summary

- Add `PUT /v1/files/{fileId}/creator` to independently update any subset of `cuid`, `cu_name`, and millisecond `created_at`.
- Require at least one field; explicitly supplied `null`, blank names, negative IDs, and negative timestamps return parameter errors before persistence.
- Persist only fields actually present in the request, leaving omitted creator fields, business fields, updater audit fields, and file version unchanged.
- Return the refreshed file and broadcast `file.updated` with the dedicated `creator` scope for both single-field and multi-field updates.
- Rebased onto the latest `develop`, including the file metadata update changes from #108.

## Validation

- `cd api && mvn test` — 209 tests passed after rebase.
- `cd api && mvn -Dtest=FileControllerUpdateCreatorTest,FileRepoUpdateTransactionTest,FileServiceBroadcastTest test` — 31 tests passed after rebase.
- `git diff --check`
